### PR TITLE
Add non-root user fluvio as default in image

### DIFF
--- a/container-build/Dockerfile
+++ b/container-build/Dockerfile
@@ -14,4 +14,13 @@ RUN chmod +x /usr/local/bin/${CONNECTOR_NAME}
 # The startup script uses this file to get the connector binary name
 RUN echo ${CONNECTOR_NAME} | tee /CONNECTOR_NAME
 
+# Add non-privileged user
+ENV USER=fluvio
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/home/$USER" \
+    "$USER"
+USER $USER 
+
 ENTRYPOINT [ "sh", "-c", "tini $CONNECTOR_NAME" ] 


### PR DESCRIPTION
Container still runs as expected, but now as a less privileged user. (Fluvio's home directory is located at `/home/fluvio`)

```
$ docker run -it --rm --entrypoint whoami infinyon/fluvio-connect-test-connector
fluvio

$ docker run -it --rm infinyon/fluvio-connect-test-connector
Produce error: ClientConfig(NoActiveProfile)
```