### PR TITLE
Move wasm crates into wasm/ workspace with default target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # Editors
 .idea/
+
+# Other
+.env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,7 @@ members = [
     "rust-connectors/sources/test-connector",
     "rust-connectors/sources/mqtt",
     "rust-connectors/sources/http",
-    "rust-connectors/utils/mocks/http-json-mock/",
-    "rust-connectors/utils/fluvio-smartstream-map/"
+    "rust-connectors/utils/mocks/http-json-mock",
 ]
 resolver = "2"
 [patch.crates-io]


### PR DESCRIPTION
Prior to this, a top-level `cargo build` would always fail because it tried to compile a wasm-specific crate without `--target=wasm32-unknown-unknown`. This PR creates a new workspace in `wasm/` that has a `.cargo/config` to set the correct default target.