### PR TITLE
[Merged by Bors] - Set default RUST_LOG

### DIFF
--- a/rust-connectors/sources/http/src/main.rs
+++ b/rust-connectors/sources/http/src/main.rs
@@ -46,7 +46,13 @@ async fn main() -> Result<()> {
     }
 
     let opts: HttpOpt = HttpOpt::from_args();
+
+    // Enable logging, setting default RUST_LOG if not given
     opts.common.enable_logging();
+    if let Err(_) | Ok("") = std::env::var("RUST_LOG").as_deref() {
+        std::env::set_var("RUST_LOG", "http=info");
+    }
+
     tracing::info!("Initializing HTTP connector");
     tracing::info!(
         "Using interval={}s, method={}, topic={}, endpoint={}",

--- a/rust-connectors/sources/mqtt/src/main.rs
+++ b/rust-connectors/sources/mqtt/src/main.rs
@@ -63,7 +63,11 @@ async fn main() -> Result<(), MqttConnectorError> {
         }
         _ => MqttOpts::from_args(),
     };
+    // Enable logging, setting default RUST_LOG if not given
     opts.common.enable_logging();
+    if let Err(_) | Ok("") = std::env::var("RUST_LOG").as_deref() {
+        std::env::set_var("RUST_LOG", "mqtt=info");
+    }
     tracing::info!("Initializing MQTT connector");
 
     let mqtt_qos = opts.qos.unwrap_or(0);


### PR DESCRIPTION
In #81 I added logging to HTTP and MQTT, but it turns out that the default log level does not include `info` messages. This PR sets `RUST_LOG` to `info` by default for HTTP and MQTT connectors.