### PR TITLE
[Merged by Bors] - Add the ability to include HTTP headers for HTTP connector

### DIFF
--- a/rust-connectors/sources/http/src/main.rs
+++ b/rust-connectors/sources/http/src/main.rs
@@ -24,6 +24,10 @@ pub struct HttpOpt {
     #[structopt(long, default_value = "300")]
     interval: u64,
 
+    /// Headers to include in the HTTP request, in "Key=Value" format
+    #[structopt(long = "header", alias = "headers")]
+    headers: Vec<String>,
+
     #[structopt(flatten)]
     #[schemars(flatten)]
     common: CommonSourceOpt,
@@ -78,6 +82,11 @@ async fn main() -> Result<()> {
         let mut req = client
             .request(method.clone(), &opts.endpoint)
             .header("Content-Type", "application/json");
+
+        let headers = opts.headers.iter().flat_map(|h| h.split_once(':'));
+        for (key, value) in headers {
+            req = req.header(key, value);
+        }
 
         if let Some(ref body) = opts.body {
             req = req.body(body.clone());

--- a/rust-connectors/sources/http/src/main.rs
+++ b/rust-connectors/sources/http/src/main.rs
@@ -79,9 +79,7 @@ async fn main() -> Result<()> {
     let method: reqwest::Method = opts.method.parse()?;
 
     while timer_stream.next().await.is_some() {
-        let mut req = client
-            .request(method.clone(), &opts.endpoint)
-            .header("Content-Type", "application/json");
+        let mut req = client.request(method.clone(), &opts.endpoint);
 
         let headers = opts.headers.iter().flat_map(|h| h.split_once(':'));
         for (key, value) in headers {


### PR DESCRIPTION
Closes #74

To test, you can run this:

```
cargo run --bin http -- --fluvio-topic github --endpoint="https://api.github.com/repos/infinyon/fluvio" --header="User-Agent:fluvio"
```

This is a good test since the GitHub API does not allow HTTP requests that do not include a `User-Agent` header. With this PR, we successfully get data from the GitHub API.