### PR TITLE
add fluvio reimports

### DIFF
--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["fluvio-imports"]
+fluvio-imports = []
+
 [dependencies]
 serde = { version = "1.0.127", features = ["derive"] }
 schemars = "0.8"

--- a/rust-connectors/common/src/lib.rs
+++ b/rust-connectors/common/src/lib.rs
@@ -1,3 +1,6 @@
-pub use fluvio::RecordKey;
+#[cfg(feature = "fluvio-imports")]
+pub mod fluvio {
+    pub use fluvio::{FluvioError, RecordKey, TopicProducer};
+}
 
 pub mod opt;

--- a/rust-connectors/sources/http/src/main.rs
+++ b/rust-connectors/sources/http/src/main.rs
@@ -1,5 +1,5 @@
+use fluvio_connectors_common::fluvio::RecordKey;
 use fluvio_connectors_common::opt::CommonSourceOpt;
-use fluvio_connectors_common::RecordKey;
 use schemars::{schema_for, JsonSchema};
 use structopt::StructOpt;
 use tokio_stream::StreamExt;

--- a/rust-connectors/sources/mqtt/Cargo.toml
+++ b/rust-connectors/sources/mqtt/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 tracing = "0.1"
-fluvio = "0.10"
 fluvio-connectors-common = { path = "../../common" }
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }
 

--- a/rust-connectors/sources/mqtt/src/error.rs
+++ b/rust-connectors/sources/mqtt/src/error.rs
@@ -1,5 +1,7 @@
 use anyhow::Error as AnyhowError;
-use fluvio::FluvioError;
+
+use fluvio_connectors_common::fluvio::FluvioError;
+
 use rumqttc::Error as MqttError;
 use rumqttc::{ClientError as MqttClientError, ConnectionError as MqttConnectionError};
 use serde_json::Error as SerdeJsonError;

--- a/rust-connectors/sources/mqtt/src/main.rs
+++ b/rust-connectors/sources/mqtt/src/main.rs
@@ -1,5 +1,5 @@
+use fluvio_connectors_common::fluvio::RecordKey;
 use fluvio_connectors_common::opt::CommonSourceOpt;
-use fluvio_connectors_common::RecordKey;
 
 mod error;
 use error::MqttConnectorError;

--- a/rust-connectors/utils/test-connector/src/produce.rs
+++ b/rust-connectors/utils/test-connector/src/produce.rs
@@ -1,5 +1,5 @@
 use crate::opts::TestConnectorOpts;
-use fluvio_connectors_common::RecordKey;
+use fluvio_connectors_common::fluvio::RecordKey;
 
 pub async fn produce(opts: TestConnectorOpts) -> anyhow::Result<()> {
     let producer = opts


### PR DESCRIPTION
This is just adding fluvio reimports so the underlying connector does not need to add explicit dependency to fluvio to import the TopicProducer and FluvioError structs