### PR TITLE
[Merged by Bors] - feat: http full record

### DIFF
--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -2,7 +2,11 @@
 name = "http"
 version = "0.1.0"
 description = "A Fluvio connector that fetches data from HTTP endpoints"
-edition = "2018"
+edition = "2021"
+
+[[bin]]
+name = "http"
+path = "src/bin/main.rs"
 
 [dependencies]
 tracing = "0.1"
@@ -12,6 +16,7 @@ tokio-stream = "0.1"
 reqwest = "0.11"
 schemars = "0.8"
 serde_json = "1"
+thiserror = "1.0"
 
 fluvio-connectors-common = { path = "../../common" }
 fluvio-dataplane-protocol = "0.9"

--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -21,3 +21,7 @@ thiserror = "1.0"
 fluvio-connectors-common = { path = "../../common" }
 fluvio-dataplane-protocol = "0.9"
 fluvio-future = { version = "0.3.9", features = ["subscriber"] }
+
+[dev-dependencies]
+rstest = "0.12"
+rstest_reuse = "0.1"

--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Fluvio connector that fetches data from HTTP endpoints"
 edition = "2021"
 

--- a/rust-connectors/sources/http/Makefile
+++ b/rust-connectors/sources/http/Makefile
@@ -1,4 +1,5 @@
 test:
 	bats ./tests/get-smartstream-test.bats
 	bats ./tests/get-test.bats
+	bats ./tests/get-test-full.bats
 	bats ./tests/post-test.bats

--- a/rust-connectors/sources/http/src/bin/main.rs
+++ b/rust-connectors/sources/http/src/bin/main.rs
@@ -38,12 +38,11 @@ async fn main() -> Result<()> {
 
     tracing::info!("Initializing HTTP connector");
     tracing::info!(
-        "Using interval={}s, method={}, output_format={}, topic={}, endpoint={}",
-        opts.interval,
-        opts.method,
-        opts.output_format,
-        opts.common.fluvio_topic,
-        opts.endpoint
+        interval = %opts.interval,
+        method = %opts.method,
+    topic = %opts.common.fluvio_topic,
+    output_format = %opts.output_format,
+    endpoint = %opts.endpoint
     );
 
     let timer = tokio::time::interval(tokio::time::Duration::from_secs(opts.interval));

--- a/rust-connectors/sources/http/src/bin/main.rs
+++ b/rust-connectors/sources/http/src/bin/main.rs
@@ -40,9 +40,9 @@ async fn main() -> Result<()> {
     tracing::info!(
         interval = %opts.interval,
         method = %opts.method,
-    topic = %opts.common.fluvio_topic,
-    output_format = %opts.output_format,
-    endpoint = %opts.endpoint
+        topic = %opts.common.fluvio_topic,
+        output_format = %opts.output_format,
+        endpoint = %opts.endpoint
     );
 
     let timer = tokio::time::interval(tokio::time::Duration::from_secs(opts.interval));
@@ -78,6 +78,7 @@ async fn main() -> Result<()> {
         let response_body = response.text().await.map_err(|e| Error::ResponseBody(e))?;
 
         let record_out = match opts.output_format.as_str() {
+            "body" => response_body,
             "full" => ::http::formatter::format_full_record(
                 &response_version,
                 &response_status,
@@ -86,7 +87,7 @@ async fn main() -> Result<()> {
                 &response_body,
             ),
 
-            _ => response_body,
+            _ => panic!("Unsupported output_format: {}", opts.output_format.as_str()),
         };
 
         tracing::debug!(%record_out, "Producing");

--- a/rust-connectors/sources/http/src/bin/main.rs
+++ b/rust-connectors/sources/http/src/bin/main.rs
@@ -1,3 +1,6 @@
+// Techdebt: Granular errors
+#![allow(clippy::redundant_closure)]
+
 use fluvio_connectors_common::fluvio::RecordKey;
 use tokio_stream::StreamExt;
 

--- a/rust-connectors/sources/http/src/bin/main.rs
+++ b/rust-connectors/sources/http/src/bin/main.rs
@@ -3,31 +3,9 @@ use tokio_stream::StreamExt;
 
 type Result<T, E = Box<dyn std::error::Error + Send + Sync + 'static>> = core::result::Result<T, E>;
 
-//use reqwest::header::HeaderMap;
 use ::http::HttpOpt;
 use schemars::schema_for;
 use structopt::StructOpt;
-
-// Prototype function, using slow format!() - evaluate using ufmt
-/*
-fn format_headers(hdr_map: &HeaderMap) -> String {
-    let mut hdr_vec = Vec::with_capacity(hdr_map.len());
-
-    for (hdr_key, hdr_val) in hdr_map.iter() {
-        let mut hdr_kv_str: Vec<&str> = Vec::with_capacity(2);
-        hdr_kv_str.push(hdr_key.as_str());
-
-        match hdr_val.to_str() {
-            Ok(v) => hdr_kv_str.push(v),
-            // Should we spend effort on lossy header when it isn't valid String?
-            Err(e) => hdr_kv_str.push(""),
-        };
-
-        hdr_vec.push(hdr_kv_str.join(": "));
-    }
-
-    hdr_vec.join("\n")
-} */
 
 use ::http::error::Error;
 

--- a/rust-connectors/sources/http/src/error.rs
+++ b/rust-connectors/sources/http/src/error.rs
@@ -2,6 +2,8 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("HTTP Record formatter error")]
+    Record(#[source] crate::formatter::HttpRecordError),
     #[error("HTTP Request error")]
     Request(#[source] reqwest::Error),
     #[error("HTTP Response body error")]

--- a/rust-connectors/sources/http/src/error.rs
+++ b/rust-connectors/sources/http/src/error.rs
@@ -1,0 +1,9 @@
+pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("HTTP Request error")]
+    Request(#[source] reqwest::Error),
+    #[error("HTTP Response body error")]
+    ResponseBody(#[source] reqwest::Error),
+}

--- a/rust-connectors/sources/http/src/formatter.rs
+++ b/rust-connectors/sources/http/src/formatter.rs
@@ -1,3 +1,6 @@
+// Pre-Allocations ::with_capacity()
+#![allow(clippy::vec_init_then_push)]
+
 /// Assembles and allocates the final full Record string
 pub fn format_full_record(
     version: &str,

--- a/rust-connectors/sources/http/src/formatter.rs
+++ b/rust-connectors/sources/http/src/formatter.rs
@@ -1,0 +1,40 @@
+/// Assembles and allocates the final full Record string
+pub fn format_full_record(
+    version: &str,
+    status: &str,
+    header_count: usize,
+    headers: &str,
+    body: &str,
+) -> String {
+    let mut record_out_parts: Vec<String> = Vec::with_capacity(4);
+    let mut status_line: Vec<String> = Vec::with_capacity(2);
+    status_line.push(version.to_owned());
+    status_line.push(status.to_owned());
+    record_out_parts.push(status_line.join(" "));
+    if header_count > 0 {
+        record_out_parts.push(headers.to_owned());
+    }
+    record_out_parts.push(String::from(""));
+    record_out_parts.push(body.to_owned());
+    record_out_parts.join("\n")
+}
+
+/// Format headers into full response
+pub fn format_reqwest_headers(hdr_map: &reqwest::header::HeaderMap) -> String {
+    let mut hdr_vec = Vec::with_capacity(hdr_map.len());
+
+    for (hdr_key, hdr_val) in hdr_map.iter() {
+        let mut hdr_kv_str: Vec<&str> = Vec::with_capacity(2);
+        hdr_kv_str.push(hdr_key.as_str());
+
+        match hdr_val.to_str() {
+            Ok(v) => hdr_kv_str.push(v),
+            // Should we spend effort on opportunistic lossy header?
+            Err(_) => hdr_kv_str.push(""),
+        };
+
+        hdr_vec.push(hdr_kv_str.join(": "));
+    }
+
+    hdr_vec.join("\n")
+}

--- a/rust-connectors/sources/http/src/formatter.rs
+++ b/rust-connectors/sources/http/src/formatter.rs
@@ -1,5 +1,4 @@
-// Pre-Allocations ::with_capacity()
-#![allow(clippy::vec_init_then_push)]
+//! Output Record Formatting
 
 /// Assembles and allocates the final full Record string
 pub fn format_full_record(
@@ -10,9 +9,7 @@ pub fn format_full_record(
     body: &str,
 ) -> String {
     let mut record_out_parts: Vec<String> = Vec::with_capacity(4);
-    let mut status_line: Vec<String> = Vec::with_capacity(2);
-    status_line.push(version.to_owned());
-    status_line.push(status.to_owned());
+    let status_line: Vec<String> = vec![version.to_owned(), status.to_owned()];
     record_out_parts.push(status_line.join(" "));
     if header_count > 0 {
         record_out_parts.push(headers.to_owned());

--- a/rust-connectors/sources/http/src/formatter.rs
+++ b/rust-connectors/sources/http/src/formatter.rs
@@ -1,61 +1,126 @@
 //! Output Record Formatting
 
-/// Assembles and allocates the final full Record string
-pub fn format_full_record(
-    version: &str,
-    status: &str,
-    header_count: usize,
-    headers: &str,
-    body: &str,
-) -> String {
-    let mut record_out_parts: Vec<String> = Vec::with_capacity(4);
-    let status_line: Vec<String> = vec![version.to_owned(), status.to_owned()];
-    record_out_parts.push(status_line.join(" "));
-    if header_count > 0 {
-        record_out_parts.push(headers.to_owned());
-    }
-    record_out_parts.push(String::from(""));
-    record_out_parts.push(body.to_owned());
-    record_out_parts.join("\n")
+#[derive(thiserror::Error, Debug)]
+pub enum HttpRecordError {}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct HttpResponseRecord {
+    pub version: String,
+    pub status_code: u16,
+    pub status_string: Option<String>,
+    pub headers: Option<Vec<HttpHeader>>,
 }
 
-/// Format headers into full response
-pub fn format_reqwest_headers(hdr_map: &reqwest::header::HeaderMap) -> String {
+#[derive(Debug, PartialEq, Eq)]
+pub struct HttpHeader {
+    pub name: String,
+    pub value: String,
+}
+
+// Fan Out Record Impl
+impl HttpResponseRecord {
+    pub fn record(&self, body: Option<&str>) -> String {
+        let mut record_out_parts: Vec<String> = Vec::with_capacity(4);
+
+        // Status Line HTTP/X XXX CANONICAL
+        let status_line: Vec<String> = vec![
+            self.version.to_owned(),
+            self.status_code.to_string(),
+            self.status_string.to_owned().unwrap_or_else(|| "".to_string()),
+        ];
+        record_out_parts.push(status_line.join(" "));
+
+        // Header lines foo: bar
+        if let Some(headers) = &self.headers {
+            let hdr_out_parts: Vec<String> = headers
+                .iter()
+                .map(|hdr| vec![hdr.name.to_owned(), hdr.value.to_owned()].join(": "))
+                .collect();
+
+            record_out_parts.push(hdr_out_parts.join("\n"));
+        }
+
+        // Body with an empty line between
+        if let Some(body) = body {
+            record_out_parts.push(String::from(""));
+            record_out_parts.push(body.to_owned());
+        }
+
+        // Fan out joined full text Record
+        record_out_parts.join("\n")
+    }
+}
+
+// Reqwest Response TryFrom helper impl.
+fn version(version: &reqwest::Version) -> String {
+    format!("{:?}", version)
+}
+
+// Reqwest Response TryFrom helper impl.
+fn status(status: &reqwest::StatusCode) -> (u16, Option<String>) {
+    let status_code = status.as_u16();
+
+    let status_string =
+        status.canonical_reason().map(|s| s.to_string());
+
+    (status_code, status_string)
+}
+
+// Reqwest Response TryFrom helper impl.
+fn headers(hdr_map: &reqwest::header::HeaderMap) -> Vec<HttpHeader> {
     let mut hdr_vec = Vec::with_capacity(hdr_map.len());
 
     for (hdr_key, hdr_val) in hdr_map.iter() {
-        let mut hdr_kv_str: Vec<&str> = Vec::with_capacity(2);
-        hdr_kv_str.push(hdr_key.as_str());
-
-        match hdr_val.to_str() {
-            Ok(v) => hdr_kv_str.push(v),
-            // Should we spend effort on opportunistic lossy header?
-            Err(_) => hdr_kv_str.push(""),
+        let hdr_value = match hdr_val.to_str() {
+            Ok(v) => v.to_owned().to_string(),
+            // Should we warn / error / spend effort on opportunistic lossy header?
+            Err(_) => String::from(""),
         };
 
-        hdr_vec.push(hdr_kv_str.join(": "));
+        hdr_vec.push(HttpHeader {
+            name: hdr_key.to_owned().to_string(),
+            value: hdr_value,
+        });
     }
 
-    hdr_vec.join("\n")
+    hdr_vec
+}
+
+// Turn reqwest Response into HttpResponseRecord
+impl TryFrom<&reqwest::Response> for HttpResponseRecord {
+    type Error = HttpRecordError;
+
+    fn try_from(response: &reqwest::Response) -> Result<Self, Self::Error> {
+        let (status_code, status_string) = status(&response.status());
+
+        Ok(Self {
+            version: version(&response.version()),
+            status_code,
+            status_string,
+            headers: Some(headers(response.headers())),
+        })
+    }
 }
 
 #[cfg(test)]
-#[allow(unused_imports)]
 mod tests {
     use super::*;
 
     use reqwest::header::{HeaderName, HeaderValue};
 
     use rstest::rstest;
+
+    #[allow(unused_imports)]
     use rstest_reuse::{self, *};
 
     fn data_test_header(
         k_prefix: &str,
         v_prefix: &str,
         count_header: usize,
-    ) -> (reqwest::header::HeaderMap, String) {
+    ) -> (reqwest::header::HeaderMap, Vec<HttpHeader>, String) {
         let mut test_header_input = reqwest::header::HeaderMap::new();
-        let mut expect_output_vec: Vec<String> = Vec::with_capacity(count_header);
+        let mut expect_output_vec_type: Vec<HttpHeader> = Vec::with_capacity(count_header);
+        let mut expect_output_vec_str: Vec<String> = Vec::with_capacity(count_header);
 
         if count_header > 0 {
             for x in 0..count_header {
@@ -73,45 +138,59 @@ mod tests {
                 if test_header_input.append(hdr_name, hdr_value) == true {
                     panic!("data_test_header ret.append -> true! duplicate?!");
                 }
-                expect_output_vec.push(format!("{}: {}", hdr_key, hdr_val));
+                expect_output_vec_type.push(HttpHeader {
+                    name: hdr_key.clone(),
+                    value: hdr_val.clone(),
+                });
+                expect_output_vec_str.push(format!("{}: {}", hdr_key, hdr_val));
             }
         }
 
-        (test_header_input, expect_output_vec.join("\n"))
+        (
+            test_header_input,
+            expect_output_vec_type,
+            expect_output_vec_str.join("\n"),
+        )
     }
 
     #[rstest(fuzz_input, case("basic"))]
     fn test_valid_format_reqwest_one_header(fuzz_input: &str) {
-        let (test_header_map, expected_result) = data_test_header(fuzz_input, fuzz_input, 1);
-        assert_eq!(format_reqwest_headers(&test_header_map), expected_result);
+        let (test_header_map, expected_result, _) = data_test_header(fuzz_input, fuzz_input, 1);
+        assert_eq!(headers(&test_header_map), expected_result);
     }
     // Unicorns not welcome as headers :(
     #[rstest(fuzz_input, case("🦄"))]
     #[should_panic]
     fn test_invalid_format_reqwest_one_header(fuzz_input: &str) {
-        let (test_header_map, expected_result) = data_test_header(fuzz_input, fuzz_input, 1);
-        assert_eq!(format_reqwest_headers(&test_header_map), expected_result);
+        let (test_header_map, expected_result, _) = data_test_header(fuzz_input, fuzz_input, 1);
+        assert_eq!(headers(&test_header_map), expected_result);
     }
 
     #[rstest(fuzz_body_input, case("basic"), case("🦄"))]
     fn test_valid_format_full_record(fuzz_body_input: &str) {
         let header_count = 1;
 
-        let (_, expected_headers) = data_test_header("basic", "basic", header_count);
+        let (_, data_headers, expected_headers) = data_test_header("basic", "basic", header_count);
 
-        let (version, status) = ("HTTP/1.1", "200");
+        let (version, status, status_string) = ("HTTP/1.1", 200, Some("OK".to_string()));
 
         let expected_record = format!(
-            "{} {}\n{}\n\n{}",
-            version, status, expected_headers, fuzz_body_input
-        );
-        let got_record = format_full_record(
+            "{} {} {}\n{}\n\n{}",
             version,
-            status,
-            header_count,
-            &expected_headers,
-            fuzz_body_input,
+            status.to_string(),
+            status_string.clone().unwrap_or("".to_string()),
+            expected_headers,
+            fuzz_body_input
         );
+
+        let response_record = HttpResponseRecord {
+            version: version.to_string(),
+            status_code: status,
+            status_string: status_string,
+            headers: Some(data_headers),
+        };
+
+        let got_record = response_record.record(Some(fuzz_body_input));
 
         assert_eq!(got_record, expected_record);
     }

--- a/rust-connectors/sources/http/src/formatter/from_reqwest.rs
+++ b/rust-connectors/sources/http/src/formatter/from_reqwest.rs
@@ -1,0 +1,78 @@
+//! reqwest input helper
+
+use crate::formatter::HttpHeader;
+use crate::formatter::HttpRecordError;
+use crate::formatter::HttpResponseRecord;
+
+impl TryFrom<&reqwest::Response> for HttpResponseRecord {
+    type Error = HttpRecordError;
+
+    fn try_from(response: &reqwest::Response) -> Result<Self, Self::Error> {
+        let (status_code, status_string) = status(&response.status());
+
+        Ok(Self {
+            version: version(&response.version()),
+            status_code,
+            status_string,
+            headers: Some(headers(response.headers())),
+        })
+    }
+}
+
+// Reqwest Response TryFrom helper impl.
+fn version(version: &reqwest::Version) -> String {
+    format!("{:?}", version)
+}
+
+// Reqwest Response TryFrom helper impl.
+fn status(status: &reqwest::StatusCode) -> (u16, Option<String>) {
+    let status_code = status.as_u16();
+
+    let status_string = status.canonical_reason().map(|s| s.to_string());
+
+    (status_code, status_string)
+}
+
+// Reqwest Response TryFrom helper impl.
+fn headers(hdr_map: &reqwest::header::HeaderMap) -> Vec<HttpHeader> {
+    let mut hdr_vec = Vec::with_capacity(hdr_map.len());
+
+    for (hdr_key, hdr_val) in hdr_map.iter() {
+        let hdr_value = match hdr_val.to_str() {
+            Ok(v) => v.to_owned().to_string(),
+            // Should we warn / error / spend effort on opportunistic lossy header?
+            Err(_) => String::from(""),
+        };
+
+        hdr_vec.push(HttpHeader {
+            name: hdr_key.to_owned().to_string(),
+            value: hdr_value,
+        });
+    }
+
+    hdr_vec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatter::tests::data_test_header;
+
+    use rstest::rstest;
+
+    #[allow(unused_imports)]
+    use rstest_reuse::{self, *};
+
+    #[rstest(fuzz_input, case("basic"))]
+    fn test_valid_format_reqwest_one_header(fuzz_input: &str) {
+        let (test_header_map, expected_result, _) = data_test_header(fuzz_input, fuzz_input, 1);
+        assert_eq!(headers(&test_header_map), expected_result);
+    }
+    // Unicorns not welcome as headers :(
+    #[rstest(fuzz_input, case("🦄"))]
+    #[should_panic]
+    fn test_invalid_format_reqwest_one_header(fuzz_input: &str) {
+        let (test_header_map, expected_result, _) = data_test_header(fuzz_input, fuzz_input, 1);
+        assert_eq!(headers(&test_header_map), expected_result);
+    }
+}

--- a/rust-connectors/sources/http/src/lib.rs
+++ b/rust-connectors/sources/http/src/lib.rs
@@ -4,27 +4,27 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug, JsonSchema, Clone)]
 pub struct HttpOpt {
-    /// Endpoint for the http connector                                                                                                                              
+    /// Endpoint for the http connector
     #[structopt(long)]
     pub endpoint: String,
 
-    /// HTTP body for the request                                                                                                                                    
+    /// HTTP body for the request
     #[structopt(long)]
     pub body: Option<String>,
 
-    /// HTTP method used in the request. Eg. GET, POST, PUT...                                                                                                       
+    /// HTTP method used in the request. Eg. GET, POST, PUT...
     #[structopt(long, default_value = "GET")]
     pub method: String,
 
-    /// Interval between each request                                                                                                                                
+    /// Interval between each request
     #[structopt(long, default_value = "300")]
     pub interval: u64,
 
-    /// Headers to include in the HTTP request, in "Key=Value" format                                                                                                
+    /// Headers to include in the HTTP request, in "Key=Value" format
     #[structopt(long = "header", alias = "headers")]
     pub headers: Vec<String>,
 
-    /// Response output format: body | full | json                                                                                                                   
+    /// Response output format: body | full    
     #[structopt(long, default_value = "body")]
     pub output_format: String,
 

--- a/rust-connectors/sources/http/src/lib.rs
+++ b/rust-connectors/sources/http/src/lib.rs
@@ -1,0 +1,37 @@
+use fluvio_connectors_common::opt::CommonSourceOpt;
+use schemars::JsonSchema;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug, JsonSchema, Clone)]
+pub struct HttpOpt {
+    /// Endpoint for the http connector                                                                                                                              
+    #[structopt(long)]
+    pub endpoint: String,
+
+    /// HTTP body for the request                                                                                                                                    
+    #[structopt(long)]
+    pub body: Option<String>,
+
+    /// HTTP method used in the request. Eg. GET, POST, PUT...                                                                                                       
+    #[structopt(long, default_value = "GET")]
+    pub method: String,
+
+    /// Interval between each request                                                                                                                                
+    #[structopt(long, default_value = "300")]
+    pub interval: u64,
+
+    /// Headers to include in the HTTP request, in "Key=Value" format                                                                                                
+    #[structopt(long = "header", alias = "headers")]
+    pub headers: Vec<String>,
+
+    /// Response output format: body | full | json                                                                                                                   
+    #[structopt(long, default_value = "body")]
+    pub output_format: String,
+
+    #[structopt(flatten)]
+    #[schemars(flatten)]
+    pub common: CommonSourceOpt,
+}
+
+pub mod error;
+pub mod formatter;

--- a/rust-connectors/sources/http/tests/get-test-full-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-full-config.yaml
@@ -1,5 +1,4 @@
-version: v1
-connector_version: dev
+version: dev
 name: http-json-connector
 type: http
 topic: http-json-connector-topic

--- a/rust-connectors/sources/http/tests/get-test-full-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-full-config.yaml
@@ -1,0 +1,13 @@
+version: v1
+connector_version: dev
+name: http-json-connector
+type: http
+topic: http-json-connector-topic
+create_topic: true
+direction: source
+parameters:
+  endpoint: http://IP_ADDRESS:8080/get
+  method: GET
+  output_format: full
+  body: ''
+  interval: 1

--- a/rust-connectors/sources/http/tests/get-test-full.bats
+++ b/rust-connectors/sources/http/tests/get-test-full.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup() {
+    cargo build -p http-json-mock
+    ../../../target/debug/http-json-mock & disown
+    MOCK_PID=$!
+    FILE=$(mktemp --suffix .yaml)
+    cp ./tests/get-test-full-config.yaml $FILE
+    UUID=$(uuidgen)
+    TOPIC=${UUID}-topic
+
+    sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
+    IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
+    sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
+    fluvio connector create --config $FILE
+}
+
+teardown() {
+    fluvio connector delete $UUID
+    fluvio topic delete $TOPIC
+    kill $MOCK_PID
+}
+
+@test "http-connector-get-full-test" {
+    count=1
+    echo "Starting consumer on topic $TOPIC"
+    sleep 13
+
+    fluvio consume -o 0 -d $TOPIC | while read input; do
+        expected="Hello, Fluvio! - $count"
+        echo $input = $expected
+        [ "$input" = "$expected" ]
+        count=$(($count + 1))
+        if [ $count -eq 10 ]; then
+            break;
+        fi
+    done
+
+}
+


### PR DESCRIPTION
Fixes #97 

**New metadata for output_format**
```rust
    /// Response output format: body | full                                                                                                                  
    #[structopt(long, default_value = "body")]
    pub output_format: String,
```
**Option output_format bahaviour**
- full spits out the full HTTP Response in full text form
- body (default) spits out the backwards compatible text body as-is like before

**Formatter Interface**

HttpResponseRecord in formatter.rs is now solely the abstract Fluvio Record formatting "Fan out" interface via record(&body)

**Implementation Detail**

TryFrom for [reqwest::Response](https://docs.rs/reqwest/latest/reqwest/struct.Response.html) in formatter/from_reqwest.rs feeds into the record data that gets fanned out.

**Gotchas**
- Header values that are not valid according to reqwest HeaderValue will exits by key but willl be empty
- Errors need some work
- Have to add record/replay scenarios for httpmock to simulate various scearios for testing

I've also added thiserror too.

**Outputs after PR**

cargo run -- --interval 1 --fluvio-topic cat-facts **--output-format full** --endpoint `https://catfact.ninja/fact`
```
HTTP/1.1 200 OK
server: nginx
date: Fri, 28 Jan 2022 19:29:38 GMT
content-type: application/json
transfer-encoding: chunked
connection: keep-alive
vary: Accept-Encoding
cache-control: no-cache, private
x-ratelimit-limit: 100
x-ratelimit-remaining: 78
access-control-allow-origin: *
set-cookie: XSRF-TOKEN=eyJpdiI6InU5RWtWWWYvRGM1d01LWWpMWXFtSlE9PSIsInZhbHVlIjoiKzN6N0JkSHlFTSszY3Q0VHJhLzQxQmxZQXBLNXZ1ZUxWTEl5cXNwbnpwaWhwd29ER3RUVlJScTJkUXRWTGt0eGNKL2lmWmxra3h2ZzMvOVlqNVZrRlhoU3pUS0hmUUM4VFVkMTVYQ2dtOEkwVVBUc2tNcmp2VzlQbHRZdXhsQWIiLCJtYWMiOiIzZjQzNTdiYWEyZGU0ZDYxZmMzMTdhYzQ2ZTc5MWYwZWFiNzM5YTlkOGY2OWEwNjMzMDZhNGU5NzA5ZDI0YjAxIiwidGFnIjoiIn0%3D; expires=Fri, 28-Jan-2022 21:29:38 GMT; path=/; samesite=lax
set-cookie: cat_facts_session=eyJpdiI6ImNZcHJaQit2aEEyK3pPZjlRM1BVcXc9PSIsInZhbHVlIjoiM3p1RlJvaVprWDdZM3JJZ0NucGdVZ2Vva1Z1NUYzUjBjR0FiQUhHK3BYUVJ6dzVhcHZYeittczhmcEtFWS8wQ05uclZjdDN3MVB6MWtXM2pFVm9UN29CRUpkS0c1NlpwdG5pRVVRTWtxeVdQRHZyZlozTSszb1R3UU9jVlhnR1MiLCJtYWMiOiJhZjdkYTI5MjU2ZmZkMTJkYmQ4NmU5YTgwZWIwNGJjZjFmMTAxN2VjZWMzYTlhN2U0Y2EwYjBhYzVmY2VjNDFjIiwidGFnIjoiIn0%3D; expires=Fri, 28-Jan-2022 21:29:38 GMT; path=/; httponly; samesite=lax
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff

{"fact":"In relation to their body size, cats have the largest eyes of any mammal.","length":73}
```

cargo run -- --interval 1 --fluvio-topic cat-facts --endpoint `https://catfact.ninja/fact`
```
{"fact":"Female cats tend to be right pawed, while male cats are more often left pawed. Interestingly, while 90% of humans are right handed, the remaining 10% of lefties also tend to be male.","length":182}
{"fact":"The most expensive cat was an Asian Leopard cat (ALC)-Domestic Shorthair (DSH) hybrid named Zeus. Zeus, who is 90% ALC and 10% DSH, has an asking price of \u00a3100,000 ($154,000).","length":175}
{"fact":"A cat usually has about 12 whiskers on each side of its face.","length":61}
```


