### PR TITLE
docs: document workflow with bors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
+# Github Workflow
+
+Conventional commits are preferred for the commit messages:
+https://www.conventionalcommits.org/en/
+
+The below should be run in the development environment:
+
+- cargo fmt
+- cargo test
+- make test  _integration tests_
+
+Bors is used with the squash-merge functionality to keep the combined commit log clean.
+
+This means that each originating PR is closed and it's commits are combined into a separate PR.
+
+This will not affect contribution statistics as the new bors PR is owned by the original contributor.
+
+The originating PR will be closed with the informational prefix [Merged by Bors] 
+
 # Adding a new connector
 
 A given connector must have a `metadata` subcommand. This subcommand will

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,14 @@
 # Github Workflow
 
-Conventional commits are preferred for the commit messages:
-https://www.conventionalcommits.org/en/
+For commits messages contributor can choose a style or use the conventional commits:
+- https://www.conventionalcommits.org/en/
 
 The below should be run in the development environment:
 
 - cargo fmt
 - cargo test
-- make test  _integration tests_
+- cargo clippy
+- make test                _integration tests_
 
 Bors is used with the squash-merge functionality to keep the combined commit log clean.
 

--- a/bors.toml
+++ b/bors.toml
@@ -2,5 +2,5 @@ status = [
     "Done",
 ]
 use_squash_merge = true
-delete_merged_branches = false
+delete_merged_branches = true
 timeout_sec = 3600 # 45 mins

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
     "Done",
 ]
-use_squash_merge = true
-delete_merged_branches = true
+use_squash_merge = false
+delete_merged_branches = false
 timeout_sec = 3600 # 45 mins

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
     "Done",
 ]
-use_squash_merge = false
+use_squash_merge = true
 delete_merged_branches = false
 timeout_sec = 3600 # 45 mins


### PR DESCRIPTION
Related to Bors [Merged by Bors] closing PRs
 - https://github.com/bors-ng/bors-ng/issues/899

**Workflow documentation**
- Add warning about PR closing vs merging until workflow is updated.

**Future Changes**
- Fail Staging run only if PR is not squashed merged. This means CI won't fail in the PR action
- Have a tool to squash merge. This only need to run prior to bors.

(The above was edited in order to Bors to use the right commit message vs initial PR)