### PR TITLE
[Merged by Bors] - tests(http): full bats with assert

### DIFF
--- a/rust-connectors/utils/bats-helpers/bats-assert/load.bash
+++ b/rust-connectors/utils/bats-helpers/bats-assert/load.bash
@@ -1,0 +1,1 @@
+source "$(dirname "${BASH_SOURCE[0]}")/src/assert.bash"

--- a/rust-connectors/utils/bats-helpers/bats-assert/src/assert.bash
+++ b/rust-connectors/utils/bats-helpers/bats-assert/src/assert.bash
@@ -1,0 +1,720 @@
+#
+# bats-assert - Common assertions for Bats
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+#
+# assert.bash
+# -----------
+#
+# Assertions are functions that perform a test and output relevant
+# information on failure to help debugging. They return 1 on failure
+# and 0 otherwise.
+#
+# All output is formatted for readability using the functions of
+# `output.bash' and sent to the standard error.
+#
+
+# Fail and display the expression if it evaluates to false.
+#
+# NOTE: The expression must be a simple command. Compound commands, such
+#       as `[[', can be used only when executed with `bash -c'.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - expression
+# Returns:
+#   0 - expression evaluates to TRUE
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert() {
+  if ! "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+      | batslib_decorate 'assertion failed' \
+      | fail
+  fi
+}
+
+# Fail and display the expression if it evaluates to true.
+#
+# NOTE: The expression must be a simple command. Compound commands, such
+#       as `[[', can be used only when executed with `bash -c'.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - expression
+# Returns:
+#   0 - expression evaluates to FALSE
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+refute() {
+  if "$@"; then
+    batslib_print_kv_single 10 'expression' "$*" \
+      | batslib_decorate 'assertion succeeded, but it was expected to fail' \
+      | fail
+  fi
+}
+
+# Fail and display details if the expected and actual values do not
+# equal. Details include both values.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - actual value
+#   $2 - expected value
+# Returns:
+#   0 - values equal
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_equal() {
+  if [[ $1 != "$2" ]]; then
+    batslib_print_kv_single_or_multi 8 \
+        'expected' "$2" \
+        'actual'   "$1" \
+      | batslib_decorate 'values do not equal' \
+      | fail
+  fi
+}
+
+# Fail and display details if `$status' is not 0. Details include
+# `$status' and `$output'.
+#
+# Globals:
+#   status
+#   output
+# Arguments:
+#   none
+# Returns:
+#   0 - `$status' is 0
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_success() {
+  if (( status != 0 )); then
+    { local -ir width=6
+      batslib_print_kv_single "$width" 'status' "$status"
+      batslib_print_kv_single_or_multi "$width" 'output' "$output"
+    } | batslib_decorate 'command failed' \
+      | fail
+  fi
+}
+
+# Fail and display details if `$status' is 0. Details include `$output'.
+#
+# Optionally, when the expected status is specified, fail when it does
+# not equal `$status'. In this case, details include the expected and
+# actual status, and `$output'.
+#
+# Globals:
+#   status
+#   output
+# Arguments:
+#   $1 - [opt] expected status
+# Returns:
+#   0 - `$status' is not 0, or
+#       `$status' equals the expected status
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_failure() {
+  (( $# > 0 )) && local -r expected="$1"
+  if (( status == 0 )); then
+    batslib_print_kv_single_or_multi 6 'output' "$output" \
+      | batslib_decorate 'command succeeded, but it was expected to fail' \
+      | fail
+  elif (( $# > 0 )) && (( status != expected )); then
+    { local -ir width=8
+      batslib_print_kv_single "$width" \
+          'expected' "$expected" \
+          'actual'   "$status"
+      batslib_print_kv_single_or_multi "$width" \
+          'output' "$output"
+    } | batslib_decorate 'command failed as expected, but status differs' \
+      | fail
+  fi
+}
+
+# Fail and display details if `$output' does not match the expected
+# output. The expected output can be specified either by the first
+# parameter or on the standard input.
+#
+# By default, literal matching is performed. The assertion fails if the
+# expected output does not equal `$output'. Details include both values.
+#
+# Option `--partial' enables partial matching. The assertion fails if
+# the expected substring cannot be found in `$output'.
+#
+# Option `--regexp' enables regular expression matching. The assertion
+# fails if the extended regular expression does not match `$output'. An
+# invalid regular expression causes an error to be displayed.
+#
+# It is an error to use partial and regular expression matching
+# simultaneously.
+#
+# Globals:
+#   output
+# Options:
+#   -p, --partial - partial matching
+#   -e, --regexp - extended regular expression matching
+# Arguments:
+#   $1 - [=STDIN] expected output
+# Returns:
+#   0 - expected matches the actual output
+#   1 - otherwise
+# Inputs:
+#   STDIN - [=$1] expected output
+# Outputs:
+#   STDERR - details, on failure
+#            error message, on error
+assert_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -p|--partial) is_mode_partial=1; shift ;;
+      -e|--regexp) is_mode_regexp=1; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+      | batslib_decorate 'ERROR: assert_output' \
+      | fail
+    return $?
+  fi
+
+  # Arguments.
+  local expected
+  (( $# == 0 )) && expected="$(cat -)" || expected="$1"
+
+  # Matching.
+  if (( is_mode_regexp )); then
+    if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      echo "Invalid extended regular expression: \`$expected'" \
+        | batslib_decorate 'ERROR: assert_output' \
+        | fail
+      return $?
+    fi
+    if ! [[ $output =~ $expected ]]; then
+      batslib_print_kv_single_or_multi 6 \
+          'regexp'  "$expected" \
+          'output' "$output" \
+        | batslib_decorate 'regular expression does not match output' \
+        | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output != *"$expected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+          'substring' "$expected" \
+          'output'    "$output" \
+        | batslib_decorate 'output does not contain substring' \
+        | fail
+    fi
+  else
+    if [[ $output != "$expected" ]]; then
+      batslib_print_kv_single_or_multi 8 \
+          'expected' "$expected" \
+          'actual'   "$output" \
+        | batslib_decorate 'output differs' \
+        | fail
+    fi
+  fi
+}
+
+# Fail and display details if `$output' matches the unexpected output.
+# The unexpected output can be specified either by the first parameter
+# or on the standard input.
+#
+# By default, literal matching is performed. The assertion fails if the
+# unexpected output equals `$output'. Details include `$output'.
+#
+# Option `--partial' enables partial matching. The assertion fails if
+# the unexpected substring is found in `$output'. The unexpected
+# substring is added to details.
+#
+# Option `--regexp' enables regular expression matching. The assertion
+# fails if the extended regular expression does matches `$output'. The
+# regular expression is added to details. An invalid regular expression
+# causes an error to be displayed.
+#
+# It is an error to use partial and regular expression matching
+# simultaneously.
+#
+# Globals:
+#   output
+# Options:
+#   -p, --partial - partial matching
+#   -e, --regexp - extended regular expression matching
+# Arguments:
+#   $1 - [=STDIN] unexpected output
+# Returns:
+#   0 - unexpected matches the actual output
+#   1 - otherwise
+# Inputs:
+#   STDIN - [=$1] unexpected output
+# Outputs:
+#   STDERR - details, on failure
+#            error message, on error
+refute_output() {
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -p|--partial) is_mode_partial=1; shift ;;
+      -e|--regexp) is_mode_regexp=1; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+      | batslib_decorate 'ERROR: refute_output' \
+      | fail
+    return $?
+  fi
+
+  # Arguments.
+  local unexpected
+  (( $# == 0 )) && unexpected="$(cat -)" || unexpected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+      | batslib_decorate 'ERROR: refute_output' \
+      | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_mode_regexp )); then
+    if [[ $output =~ $unexpected ]] || (( $? == 0 )); then
+      batslib_print_kv_single_or_multi 6 \
+          'regexp'  "$unexpected" \
+          'output' "$output" \
+        | batslib_decorate 'regular expression should not match output' \
+        | fail
+    fi
+  elif (( is_mode_partial )); then
+    if [[ $output == *"$unexpected"* ]]; then
+      batslib_print_kv_single_or_multi 9 \
+          'substring' "$unexpected" \
+          'output'    "$output" \
+        | batslib_decorate 'output should not contain substring' \
+        | fail
+    fi
+  else
+    if [[ $output == "$unexpected" ]]; then
+      batslib_print_kv_single_or_multi 6 \
+          'output' "$output" \
+        | batslib_decorate 'output equals, but it was expected to differ' \
+        | fail
+    fi
+  fi
+}
+
+# Fail and display details if the expected line is not found in the
+# output (default) or in a specific line of it.
+#
+# By default, the entire output is searched for the expected line. The
+# expected line is matched against every element of `${lines[@]}'. If no
+# match is found, the assertion fails. Details include the expected line
+# and `${lines[@]}'.
+#
+# When `--index <idx>' is specified, only the <idx>-th line is matched.
+# If the expected line does not match `${lines[<idx>]}', the assertion
+# fails. Details include <idx> and the compared lines.
+#
+# By default, literal matching is performed. A literal match fails if
+# the expected string does not equal the matched string.
+#
+# Option `--partial' enables partial matching. A partial match fails if
+# the expected substring is not found in the target string.
+#
+# Option `--regexp' enables regular expression matching. A regular
+# expression match fails if the extended regular expression does not
+# match the target string. An invalid regular expression causes an error
+# to be displayed.
+#
+# It is an error to use partial and regular expression matching
+# simultaneously.
+#
+# Mandatory arguments to long options are mandatory for short options
+# too.
+#
+# Globals:
+#   output
+#   lines
+# Options:
+#   -n, --index <idx> - match the <idx>-th line
+#   -p, --partial - partial matching
+#   -e, --regexp - extended regular expression matching
+# Arguments:
+#   $1 - expected line
+# Returns:
+#   0 - match found
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+#            error message, on error
+# FIXME(ztombol): Display `${lines[@]}' instead of `$output'!
+assert_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -n|--index)
+        if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+          echo "\`--index' requires an integer argument: \`$2'" \
+            | batslib_decorate 'ERROR: assert_line' \
+            | fail
+          return $?
+        fi
+        is_match_line=1
+        local -ri idx="$2"
+        shift 2
+        ;;
+      -p|--partial) is_mode_partial=1; shift ;;
+      -e|--regexp) is_mode_regexp=1; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+      | batslib_decorate 'ERROR: assert_line' \
+      | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r expected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $expected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$expected'" \
+      | batslib_decorate 'ERROR: assert_line' \
+      | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if ! [[ ${lines[$idx]} =~ $expected ]]; then
+        batslib_print_kv_single 6 \
+            'index' "$idx" \
+            'regexp' "$expected" \
+            'line'  "${lines[$idx]}" \
+          | batslib_decorate 'regular expression does not match line' \
+          | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} != *"$expected"* ]]; then
+        batslib_print_kv_single 9 \
+            'index'     "$idx" \
+            'substring' "$expected" \
+            'line'      "${lines[$idx]}" \
+          | batslib_decorate 'line does not contain substring' \
+          | fail
+      fi
+    else
+      if [[ ${lines[$idx]} != "$expected" ]]; then
+        batslib_print_kv_single 8 \
+            'index'    "$idx" \
+            'expected' "$expected" \
+            'actual'   "${lines[$idx]}" \
+          | batslib_decorate 'line differs' \
+          | fail
+      fi
+    fi
+  else
+    # Contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} =~ $expected ]] && return 0
+      done
+      { local -ar single=(
+          'regexp'  "$expected"
+        )
+        local -ar may_be_multi=(
+          'output' "$output"
+        )
+        local -ir width="$( batslib_get_max_single_line_key_width \
+                              "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } | batslib_decorate 'no output line matches regular expression' \
+        | fail
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == *"$expected"* ]] && return 0
+      done
+      { local -ar single=(
+          'substring' "$expected"
+        )
+        local -ar may_be_multi=(
+          'output'    "$output"
+        )
+        local -ir width="$( batslib_get_max_single_line_key_width \
+                              "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } | batslib_decorate 'no output line contains substring' \
+        | fail
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        [[ ${lines[$idx]} == "$expected" ]] && return 0
+      done
+      { local -ar single=(
+          'line'   "$expected"
+        )
+        local -ar may_be_multi=(
+          'output' "$output"
+        )
+        local -ir width="$( batslib_get_max_single_line_key_width \
+                            "${single[@]}" "${may_be_multi[@]}" )"
+        batslib_print_kv_single "$width" "${single[@]}"
+        batslib_print_kv_single_or_multi "$width" "${may_be_multi[@]}"
+      } | batslib_decorate 'output does not contain line' \
+        | fail
+    fi
+  fi
+}
+
+# Fail and display details if the unexpected line is found in the output
+# (default) or in a specific line of it.
+#
+# By default, the entire output is searched for the unexpected line. The
+# unexpected line is matched against every element of `${lines[@]}'. If
+# a match is found, the assertion fails. Details include the unexpected
+# line, the index of the first match and `${lines[@]}' with the matching
+# line highlighted if `${lines[@]}' is longer than one line.
+#
+# When `--index <idx>' is specified, only the <idx>-th line is matched.
+# If the unexpected line matches `${lines[<idx>]}', the assertion fails.
+# Details include <idx> and the unexpected line.
+#
+# By default, literal matching is performed. A literal match fails if
+# the unexpected string does not equal the matched string.
+#
+# Option `--partial' enables partial matching. A partial match fails if
+# the unexpected substring is found in the target string. When used with
+# `--index <idx>', the unexpected substring is also displayed on
+# failure.
+#
+# Option `--regexp' enables regular expression matching. A regular
+# expression match fails if the extended regular expression matches the
+# target string. When used with `--index <idx>', the regular expression
+# is also displayed on failure. An invalid regular expression causes an
+# error to be displayed.
+#
+# It is an error to use partial and regular expression matching
+# simultaneously.
+#
+# Mandatory arguments to long options are mandatory for short options
+# too.
+#
+# Globals:
+#   output
+#   lines
+# Options:
+#   -n, --index <idx> - match the <idx>-th line
+#   -p, --partial - partial matching
+#   -e, --regexp - extended regular expression matching
+# Arguments:
+#   $1 - unexpected line
+# Returns:
+#   0 - match not found
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+#            error message, on error
+# FIXME(ztombol): Display `${lines[@]}' instead of `$output'!
+refute_line() {
+  local -i is_match_line=0
+  local -i is_mode_partial=0
+  local -i is_mode_regexp=0
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -n|--index)
+        if (( $# < 2 )) || ! [[ $2 =~ ^([0-9]|[1-9][0-9]+)$ ]]; then
+          echo "\`--index' requires an integer argument: \`$2'" \
+            | batslib_decorate 'ERROR: refute_line' \
+            | fail
+          return $?
+        fi
+        is_match_line=1
+        local -ri idx="$2"
+        shift 2
+        ;;
+      -p|--partial) is_mode_partial=1; shift ;;
+      -e|--regexp) is_mode_regexp=1; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  if (( is_mode_partial )) && (( is_mode_regexp )); then
+    echo "\`--partial' and \`--regexp' are mutually exclusive" \
+      | batslib_decorate 'ERROR: refute_line' \
+      | fail
+    return $?
+  fi
+
+  # Arguments.
+  local -r unexpected="$1"
+
+  if (( is_mode_regexp == 1 )) && [[ '' =~ $unexpected ]] || (( $? == 2 )); then
+    echo "Invalid extended regular expression: \`$unexpected'" \
+      | batslib_decorate 'ERROR: refute_line' \
+      | fail
+    return $?
+  fi
+
+  # Matching.
+  if (( is_match_line )); then
+    # Specific line.
+    if (( is_mode_regexp )); then
+      if [[ ${lines[$idx]} =~ $unexpected ]] || (( $? == 0 )); then
+        batslib_print_kv_single 6 \
+            'index' "$idx" \
+            'regexp' "$unexpected" \
+            'line'  "${lines[$idx]}" \
+          | batslib_decorate 'regular expression should not match line' \
+          | fail
+      fi
+    elif (( is_mode_partial )); then
+      if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+        batslib_print_kv_single 9 \
+            'index'     "$idx" \
+            'substring' "$unexpected" \
+            'line'      "${lines[$idx]}" \
+          | batslib_decorate 'line should not contain substring' \
+          | fail
+      fi
+    else
+      if [[ ${lines[$idx]} == "$unexpected" ]]; then
+        batslib_print_kv_single 5 \
+            'index' "$idx" \
+            'line'  "${lines[$idx]}" \
+          | batslib_decorate 'line should differ' \
+          | fail
+      fi
+    fi
+  else
+    # Line contained in output.
+    if (( is_mode_regexp )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} =~ $unexpected ]]; then
+          { local -ar single=(
+              'regexp'  "$unexpected"
+              'index'  "$idx"
+            )
+            local -a may_be_multi=(
+              'output' "$output"
+            )
+            local -ir width="$( batslib_get_max_single_line_key_width \
+                                "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" \
+                                    | batslib_prefix \
+                                    | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } | batslib_decorate 'no line should match the regular expression' \
+            | fail
+          return $?
+        fi
+      done
+    elif (( is_mode_partial )); then
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == *"$unexpected"* ]]; then
+          { local -ar single=(
+              'substring' "$unexpected"
+              'index'     "$idx"
+            )
+            local -a may_be_multi=(
+              'output'    "$output"
+            )
+            local -ir width="$( batslib_get_max_single_line_key_width \
+                                "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" \
+                                    | batslib_prefix \
+                                    | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } | batslib_decorate 'no line should contain substring' \
+            | fail
+          return $?
+        fi
+      done
+    else
+      local -i idx
+      for (( idx = 0; idx < ${#lines[@]}; ++idx )); do
+        if [[ ${lines[$idx]} == "$unexpected" ]]; then
+          { local -ar single=(
+              'line'   "$unexpected"
+              'index'  "$idx"
+            )
+            local -a may_be_multi=(
+              'output' "$output"
+            )
+            local -ir width="$( batslib_get_max_single_line_key_width \
+                                "${single[@]}" "${may_be_multi[@]}" )"
+            batslib_print_kv_single "$width" "${single[@]}"
+            if batslib_is_single_line "${may_be_multi[1]}"; then
+              batslib_print_kv_single "$width" "${may_be_multi[@]}"
+            else
+              may_be_multi[1]="$( printf '%s' "${may_be_multi[1]}" \
+                                    | batslib_prefix \
+                                    | batslib_mark '>' "$idx" )"
+              batslib_print_kv_multi "${may_be_multi[@]}"
+            fi
+          } | batslib_decorate 'line should not be in output' \
+            | fail
+          return $?
+        fi
+      done
+    fi
+  fi
+}

--- a/rust-connectors/utils/bats-helpers/bats-support/load.bash
+++ b/rust-connectors/utils/bats-helpers/bats-support/load.bash
@@ -1,0 +1,3 @@
+source "$(dirname "${BASH_SOURCE[0]}")/src/output.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/src/error.bash"
+source "$(dirname "${BASH_SOURCE[0]}")/src/lang.bash"

--- a/rust-connectors/utils/bats-helpers/bats-support/src/error.bash
+++ b/rust-connectors/utils/bats-helpers/bats-support/src/error.bash
@@ -1,0 +1,41 @@
+#
+# bats-support - Supporting library for Bats test helpers
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+#
+# error.bash
+# ----------
+#
+# Functions implementing error reporting. Used by public helper
+# functions or test suits directly.
+#
+
+# Fail and display a message. When no parameters are specified, the
+# message is read from the standard input. Other functions use this to
+# report failure.
+#
+# Globals:
+#   none
+# Arguments:
+#   $@ - [=STDIN] message
+# Returns:
+#   1 - always
+# Inputs:
+#   STDIN - [=$@] message
+# Outputs:
+#   STDERR - message
+fail() {
+  (( $# == 0 )) && batslib_err || batslib_err "$@"
+  return 1
+}

--- a/rust-connectors/utils/bats-helpers/bats-support/src/lang.bash
+++ b/rust-connectors/utils/bats-helpers/bats-support/src/lang.bash
@@ -1,0 +1,73 @@
+#
+# bats-util - Various auxiliary functions for Bats
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>.
+#
+
+#
+# lang.bash
+# ---------
+#
+# Bash language and execution related functions. Used by public helper
+# functions.
+#
+
+# Check whether the calling function was called from a given function.
+#
+# By default, direct invocation is checked. The function succeeds if the
+# calling function was called directly from the given function. In other
+# words, if the given function is the next element on the call stack.
+#
+# When `--indirect' is specified, indirect invocation is checked. The
+# function succeeds if the calling function was called from the given
+# function with any number of intermediate calls. In other words, if the
+# given function can be found somewhere on the call stack.
+#
+# Direct invocation is a form of indirect invocation with zero
+# intermediate calls.
+#
+# Globals:
+#   FUNCNAME
+# Options:
+#   -i, --indirect - check indirect invocation
+# Arguments:
+#   $1 - calling function's name
+# Returns:
+#   0 - current function was called from the given function
+#   1 - otherwise
+batslib_is_caller() {
+  local -i is_mode_direct=1
+
+  # Handle options.
+  while (( $# > 0 )); do
+    case "$1" in
+      -i|--indirect) is_mode_direct=0; shift ;;
+      --) shift; break ;;
+      *) break ;;
+    esac
+  done
+
+  # Arguments.
+  local -r func="$1"
+
+  # Check call stack.
+  if (( is_mode_direct )); then
+    [[ $func == "${FUNCNAME[2]}" ]] && return 0
+  else
+    local -i depth
+    for (( depth=2; depth<${#FUNCNAME[@]}; ++depth )); do
+      [[ $func == "${FUNCNAME[$depth]}" ]] && return 0
+    done
+  fi
+
+  return 1
+}

--- a/rust-connectors/utils/bats-helpers/bats-support/src/output.bash
+++ b/rust-connectors/utils/bats-helpers/bats-support/src/output.bash
@@ -1,0 +1,279 @@
+#
+# bats-support - Supporting library for Bats test helpers
+#
+# Written in 2016 by Zoltan Tombol <zoltan dot tombol at gmail dot com>
+#
+# To the extent possible under law, the author(s) have dedicated all
+# copyright and related and neighboring rights to this software to the
+# public domain worldwide. This software is distributed without any
+# warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication
+# along with this software. If not, see
+# <http://creativecommons.org/publicdomain/zero/1.0/>. 
+#
+
+#
+# output.bash
+# -----------
+#
+# Private functions implementing output formatting. Used by public
+# helper functions.
+#
+
+# Print a message to the standard error. When no parameters are
+# specified, the message is read from the standard input.
+#
+# Globals:
+#   none
+# Arguments:
+#   $@ - [=STDIN] message
+# Returns:
+#   none
+# Inputs:
+#   STDIN - [=$@] message
+# Outputs:
+#   STDERR - message
+batslib_err() {
+  { if (( $# > 0 )); then
+      echo "$@"
+    else
+      cat -
+    fi
+  } >&2
+}
+
+# Count the number of lines in the given string.
+#
+# TODO(ztombol): Fix tests and remove this note after #93 is resolved!
+# NOTE: Due to a bug in Bats, `batslib_count_lines "$output"' does not
+#       give the same result as `${#lines[@]}' when the output contains
+#       empty lines.
+#       See PR #93 (https://github.com/sstephenson/bats/pull/93).
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - string
+# Returns:
+#   none
+# Outputs:
+#   STDOUT - number of lines
+batslib_count_lines() {
+  local -i n_lines=0
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    (( ++n_lines ))
+  done < <(printf '%s' "$1")
+  echo "$n_lines"
+}
+
+# Determine whether all strings are single-line.
+#
+# Globals:
+#   none
+# Arguments:
+#   $@ - strings
+# Returns:
+#   0 - all strings are single-line
+#   1 - otherwise
+batslib_is_single_line() {
+  for string in "$@"; do
+    (( $(batslib_count_lines "$string") > 1 )) && return 1
+  done
+  return 0
+}
+
+# Determine the length of the longest key that has a single-line value.
+#
+# This function is useful in determining the correct width of the key
+# column in two-column format when some keys may have multi-line values
+# and thus should be excluded.
+#
+# Globals:
+#   none
+# Arguments:
+#   $odd - key
+#   $even - value of the previous key
+# Returns:
+#   none
+# Outputs:
+#   STDOUT - length of longest key
+batslib_get_max_single_line_key_width() {
+  local -i max_len=-1
+  while (( $# != 0 )); do
+    local -i key_len="${#1}"
+    batslib_is_single_line "$2" && (( key_len > max_len )) && max_len="$key_len"
+    shift 2
+  done
+  echo "$max_len"
+}
+
+# Print key-value pairs in two-column format.
+#
+# Keys are displayed in the first column, and their corresponding values
+# in the second. To evenly line up values, the key column is fixed-width
+# and its width is specified with the first parameter (possibly computed
+# using `batslib_get_max_single_line_key_width').
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - width of key column
+#   $even - key
+#   $odd - value of the previous key
+# Returns:
+#   none
+# Outputs:
+#   STDOUT - formatted key-value pairs
+batslib_print_kv_single() {
+  local -ir col_width="$1"; shift
+  while (( $# != 0 )); do
+    printf '%-*s : %s\n' "$col_width" "$1" "$2"
+    shift 2
+  done
+}
+
+# Print key-value pairs in multi-line format.
+#
+# The key is displayed first with the number of lines of its
+# corresponding value in parenthesis. Next, starting on the next line,
+# the value is displayed. For better readability, it is recommended to
+# indent values using `batslib_prefix'.
+#
+# Globals:
+#   none
+# Arguments:
+#   $odd - key
+#   $even - value of the previous key
+# Returns:
+#   none
+# Outputs:
+#   STDOUT - formatted key-value pairs
+batslib_print_kv_multi() {
+  while (( $# != 0 )); do
+    printf '%s (%d lines):\n' "$1" "$( batslib_count_lines "$2" )"
+    printf '%s\n' "$2"
+    shift 2
+  done
+}
+
+# Print all key-value pairs in either two-column or multi-line format
+# depending on whether all values are single-line.
+#
+# If all values are single-line, print all pairs in two-column format
+# with the specified key column width (identical to using
+# `batslib_print_kv_single').
+#
+# Otherwise, print all pairs in multi-line format after indenting values
+# with two spaces for readability (identical to using `batslib_prefix'
+# and `batslib_print_kv_multi')
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - width of key column (for two-column format)
+#   $even - key
+#   $odd - value of the previous key
+# Returns:
+#   none
+# Outputs:
+#   STDOUT - formatted key-value pairs
+batslib_print_kv_single_or_multi() {
+  local -ir width="$1"; shift
+  local -a pairs=( "$@" )
+
+  local -a values=()
+  local -i i
+  for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+    values+=( "${pairs[$i]}" )
+  done
+
+  if batslib_is_single_line "${values[@]}"; then
+    batslib_print_kv_single "$width" "${pairs[@]}"
+  else
+    local -i i
+    for (( i=1; i < ${#pairs[@]}; i+=2 )); do
+      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+    done
+    batslib_print_kv_multi "${pairs[@]}"
+  fi
+}
+
+# Prefix each line read from the standard input with the given string.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - [=  ] prefix string
+# Returns:
+#   none
+# Inputs:
+#   STDIN - lines
+# Outputs:
+#   STDOUT - prefixed lines
+batslib_prefix() {
+  local -r prefix="${1:-  }"
+  local line
+  while IFS='' read -r line || [[ -n $line ]]; do
+    printf '%s%s\n' "$prefix" "$line"
+  done
+}
+
+# Mark select lines of the text read from the standard input by
+# overwriting their beginning with the given string.
+#
+# Usually the input is indented by a few spaces using `batslib_prefix'
+# first.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - marking string
+#   $@ - indices (zero-based) of lines to mark
+# Returns:
+#   none
+# Inputs:
+#   STDIN - lines
+# Outputs:
+#   STDOUT - lines after marking
+batslib_mark() {
+  local -r symbol="$1"; shift
+  # Sort line numbers.
+  set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
+
+  local line
+  local -i idx=0
+  while IFS='' read -r line || [[ -n $line ]]; do
+    if (( ${1:--1} == idx )); then
+      printf '%s\n' "${symbol}${line:${#symbol}}"
+      shift
+    else
+      printf '%s\n' "$line"
+    fi
+    (( ++idx ))
+  done
+}
+
+# Enclose the input text in header and footer lines.
+#
+# The header contains the given string as title. The output is preceded
+# and followed by an additional newline to make it stand out more.
+#
+# Globals:
+#   none
+# Arguments:
+#   $1 - title
+# Returns:
+#   none
+# Inputs:
+#   STDIN - text
+# Outputs:
+#   STDOUT - decorated text
+batslib_decorate() {
+  echo
+  echo "-- $1 --"
+  cat -
+  echo '--'
+  echo
+}


### PR DESCRIPTION
**CI Integration test for http full**

- Paying off the claimed techdebt from 
#127 
- Further CD compatible integration tests to be worked on:
#134 

**Notes**

I had to add bats's assert and support libs in order to make this work within bats-bash constraints.

Otherwise it is painful to deal with multi-line in bash.

The sleep x as before probably needs refactoring to instead ensure the topic is ready and consumable

I wanted initially to load a regex from a file and then run it via the bats assert_output --regexp but bats-bash either;
- only reads the first line via $(cat <file)
- read -rd '' doesn't work for some reason giving empty read
- whilst piping multiple reads per line in while bats seems to stop concatenating off local scope. 

So instead of regex I settled with assert_output --partial to test status, header and body parts that come from the mock.

It could have been fixture==fixture assert but there is the date and other header(s) that keeps changing.

get-test-full.regex I intended to load into bats_assert --regexp but I doubt it would have worked as multiline regex
```
^HTTP/1.1 200 OK
(.+?): (.+?\n){1,}

Hello, Fluvio! - \d+$
```