### PR TITLE
feat(http): json

### DIFF
--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Fluvio connector that fetches data from HTTP endpoints"
 edition = "2021"
 
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 reqwest = "0.11"
 schemars = "0.8"
+serde = "1"
 serde_json = "1"
 thiserror = "1.0"
 

--- a/rust-connectors/sources/http/Makefile
+++ b/rust-connectors/sources/http/Makefile
@@ -1,5 +1,7 @@
 test:
 	bats ./tests/get-smartstream-test.bats
 	bats ./tests/get-test.bats
+	bats ./tests/get-test-json.bats
 	bats ./tests/get-test-full.bats
+	bats ./tests/get-test-full-json.bats
 	bats ./tests/post-test.bats

--- a/rust-connectors/sources/http/src/formatter.rs
+++ b/rust-connectors/sources/http/src/formatter.rs
@@ -1,17 +1,34 @@
 //! Output Record Formatting
 
-// Implements TryFrom<reqwest::Response>
+// Input implementations
+// ---------------------------
+// HttpResponseRecord Implements
+// - TryFrom<reqwest::Response>
 mod from_reqwest;
 
-#[derive(thiserror::Error, Debug)]
-pub enum HttpRecordError {}
+// Output Implementations
+// ---------------------------
+// HttpJsonRecord Implements
+// - TryFrom<HttpResponseRecord>
+// - ToString
+mod to_json;
+// Techdebt: Move text to mod to_text;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug)]
+pub enum HttpRecordError {
+    #[error("Options output_parts`{0}` and/or type`{1}` Setting Error")]
+    OutputOptions(String, String),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct HttpResponseRecord {
-    pub version: String,
-    pub status_code: u16,
+    pub version: Option<String>,
+    pub status_code: Option<u16>,
     pub status_string: Option<String>,
     pub headers: Option<Vec<HttpHeader>>,
+    pub body: Option<String>,
+    pub output_type: Option<HttpOutputType>,
+    pub output_parts: Option<HttpOutputParts>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -20,34 +37,118 @@ pub struct HttpHeader {
     pub value: String,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum HttpOutputType {
+    HttpRecordText,
+    HttpRecordJSON,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum HttpOutputParts {
+    HttpRecordFull,
+    HttpRecordBody,
+}
+
 // Fan Out Record Impl
 impl HttpResponseRecord {
-    pub fn record(&self, body: Option<&str>) -> String {
-        let mut record_out_parts: Vec<String> = Vec::with_capacity(4);
+    /// Configure Record output_type and output_parts together
+    pub fn configure_output(
+        &mut self,
+        output_type: &str,
+        output_parts: &str,
+    ) -> Result<(), HttpRecordError> {
+        let new_output_parts = match output_parts {
+            "full" => Some(HttpOutputParts::HttpRecordFull),
+            "body" => Some(HttpOutputParts::HttpRecordBody),
+            _ => None,
+        };
+
+        let new_output_type = match output_type {
+            "json" => Some(HttpOutputType::HttpRecordJSON),
+            "text" => Some(HttpOutputType::HttpRecordText),
+            _ => None,
+        };
+
+        if new_output_type != None && new_output_parts != None {
+            self.output_type = new_output_type;
+            self.output_parts = new_output_parts;
+
+            Ok(())
+        } else {
+            Err(HttpRecordError::OutputOptions(
+                output_type.to_string(),
+                output_parts.to_string(),
+            ))
+        }
+    }
+    /// Record Fan Out based on previously set output()
+    pub fn record(&mut self, body: Option<&str>) -> String {
+        match self.output_type {
+            Some(HttpOutputType::HttpRecordJSON) => self.record_json(body),
+            Some(HttpOutputType::HttpRecordText) => self.record_text(body),
+
+            // Naive panics?
+            _ => panic!("ERROR: record called without output_parts set via output() ?"),
+        }
+    }
+    /// JSON Record<String> Fan Out
+    pub fn record_json(&mut self, body: Option<&str>) -> String {
+        self.body = body.map(|b| b.to_owned());
+
+        let json_rec = match self.output_parts {
+            Some(HttpOutputParts::HttpRecordFull) => {
+                to_json::HttpJsonRecord::try_from(self).unwrap()
+            }
+            Some(HttpOutputParts::HttpRecordBody) => {
+                let mut _rec = HttpResponseRecord {
+                    body: Some(body.unwrap_or("").to_owned()),
+                    ..Default::default()
+                };
+
+                to_json::HttpJsonRecord::try_from(&mut _rec).unwrap()
+            }
+            _ => panic!("BUG record_json() Unknown JSON Record type or not set?"),
+        };
+
+        json_rec.to_string()
+    }
+    /// Text Record<String> Fan Out
+    pub fn record_text(&self, body: Option<&str>) -> String {
+        let mut record_out_parts: Vec<String> = match self.output_parts {
+            Some(HttpOutputParts::HttpRecordFull) => Vec::with_capacity(4),
+            Some(HttpOutputParts::HttpRecordBody) => Vec::with_capacity(1),
+            None => panic!("record_text called with no HttpOutputParts?"),
+        };
 
         // Status Line HTTP/X XXX CANONICAL
-        let status_line: Vec<String> = vec![
-            self.version.to_owned(),
-            self.status_code.to_string(),
-            self.status_string
-                .to_owned()
-                .unwrap_or_else(|| "".to_string()),
-        ];
-        record_out_parts.push(status_line.join(" "));
+        if self.output_parts == Some(HttpOutputParts::HttpRecordFull) {
+            let status_line: Vec<String> = vec![
+                self.version.to_owned().unwrap_or_else(|| "".to_string()),
+                self.status_code.unwrap_or(0).to_string(),
+                self.status_string
+                    .to_owned()
+                    .unwrap_or_else(|| "".to_string()),
+            ];
+            record_out_parts.push(status_line.join(" "));
+        }
 
         // Header lines foo: bar
-        if let Some(headers) = &self.headers {
-            let hdr_out_parts: Vec<String> = headers
-                .iter()
-                .map(|hdr| vec![hdr.name.to_owned(), hdr.value.to_owned()].join(": "))
-                .collect();
+        if self.output_parts == Some(HttpOutputParts::HttpRecordFull) {
+            if let Some(headers) = &self.headers {
+                let hdr_out_parts: Vec<String> = headers
+                    .iter()
+                    .map(|hdr| vec![hdr.name.to_owned(), hdr.value.to_owned()].join(": "))
+                    .collect();
 
-            record_out_parts.push(hdr_out_parts.join("\n"));
+                record_out_parts.push(hdr_out_parts.join("\n"));
+            }
         }
 
         // Body with an empty line between
         if let Some(body) = body {
-            record_out_parts.push(String::from(""));
+            if self.output_parts == Some(HttpOutputParts::HttpRecordFull) {
+                record_out_parts.push(String::from(""));
+            }
             record_out_parts.push(body.to_owned());
         }
 
@@ -108,30 +209,37 @@ mod tests {
     }
 
     #[rstest(fuzz_body_input, case("basic"), case("🦄"))]
-    fn test_valid_format_full_record(fuzz_body_input: &str) {
+    fn test_valid_format_full_record_text(fuzz_body_input: &str) {
         let header_count = 1;
 
         let (_, data_headers, expected_headers) = data_test_header("basic", "basic", header_count);
 
-        let (version, status, status_string) = ("HTTP/1.1", 200, Some("OK".to_string()));
+        let (version, status, status_string) = (
+            Some("HTTP/1.1".to_string()),
+            Some(200),
+            Some("OK".to_string()),
+        );
 
         let expected_record = format!(
             "{} {} {}\n{}\n\n{}",
-            version,
-            status.to_string(),
+            version.clone().unwrap(),
+            status.clone().unwrap(),
             status_string.clone().unwrap_or("".to_string()),
             expected_headers,
             fuzz_body_input
         );
 
         let response_record = HttpResponseRecord {
-            version: version.to_string(),
+            version: version,
             status_code: status,
             status_string: status_string,
             headers: Some(data_headers),
+            body: None,
+            output_parts: Some(HttpOutputParts::HttpRecordFull),
+            output_type: Some(HttpOutputType::HttpRecordText),
         };
 
-        let got_record = response_record.record(Some(fuzz_body_input));
+        let got_record = response_record.record_text(Some(fuzz_body_input));
 
         assert_eq!(got_record, expected_record);
     }

--- a/rust-connectors/sources/http/src/formatter/from_reqwest.rs
+++ b/rust-connectors/sources/http/src/formatter/from_reqwest.rs
@@ -11,10 +11,13 @@ impl TryFrom<&reqwest::Response> for HttpResponseRecord {
         let (status_code, status_string) = status(&response.status());
 
         Ok(Self {
-            version: version(&response.version()),
+            version: Some(version(&response.version())),
             status_code,
             status_string,
             headers: Some(headers(response.headers())),
+            body: None,
+            output_type: None,
+            output_parts: None,
         })
     }
 }
@@ -25,12 +28,12 @@ fn version(version: &reqwest::Version) -> String {
 }
 
 // Reqwest Response TryFrom helper impl.
-fn status(status: &reqwest::StatusCode) -> (u16, Option<String>) {
+fn status(status: &reqwest::StatusCode) -> (Option<u16>, Option<String>) {
     let status_code = status.as_u16();
 
     let status_string = status.canonical_reason().map(|s| s.to_string());
 
-    (status_code, status_string)
+    (Some(status_code), status_string)
 }
 
 // Reqwest Response TryFrom helper impl.

--- a/rust-connectors/sources/http/src/formatter/to_json.rs
+++ b/rust-connectors/sources/http/src/formatter/to_json.rs
@@ -1,0 +1,131 @@
+//! JSON output helper
+
+use crate::formatter::HttpHeader;
+use crate::formatter::HttpRecordError;
+use crate::formatter::HttpResponseRecord;
+
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// JSON Record (Response Status) Serialisation
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct HttpJsonStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub string: Option<String>,
+}
+
+/// JSON Record (Response) Serialisation
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct HttpJsonRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<HttpJsonStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<HashMap<String, JsonHeadersValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+/// JSON Record (Header Values) Serialisation
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum JsonHeadersValue {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl ToString for HttpJsonRecord {
+    fn to_string(&self) -> String {
+        // Naive. Error needs to be handled. try_string() -> Result<R, E> ?
+        serde_json::to_string(&self).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+
+impl TryFrom<&mut HttpResponseRecord> for HttpJsonRecord {
+    type Error = HttpRecordError;
+
+    fn try_from(resp_record: &mut HttpResponseRecord) -> Result<Self, Self::Error> {
+        let json_headers = resp_record.headers.as_ref().map(|h| headers_to_json(h));
+
+        Ok(HttpJsonRecord {
+            status: Some(HttpJsonStatus {
+                version: resp_record.version.to_owned(),
+                code: resp_record.status_code.to_owned(),
+                string: resp_record.status_string.to_owned(),
+            }),
+            header: json_headers,
+            body: resp_record.body.to_owned(),
+        })
+    }
+}
+
+use crate::formatter::to_json::JsonHeadersValue::{Many, One};
+use std::collections::hash_map::Entry;
+
+fn headers_to_json(in_hdrs: &[HttpHeader]) -> HashMap<String, JsonHeadersValue> {
+    let mut out = HashMap::new();
+
+    for hdr in in_hdrs {
+        if let Entry::Occupied(mut o) = out.entry(hdr.name.to_owned()) {
+            match o.get_mut() {
+                One(cur_val_string) => {
+                    *o.into_mut() = Many(vec![cur_val_string.to_owned(), hdr.value.to_owned()]);
+                }
+                Many(itms) => {
+                    itms.push(hdr.value.to_owned());
+                }
+            };
+        } else {
+            out.insert(hdr.name.to_owned(), One(hdr.value.to_owned()));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rstest::rstest;
+
+    use crate::formatter::tests::data_test_header;
+
+    #[rstest(fuzz_key, fuzz_val, case("basic", "basic"), case("basic", "🦄"))]
+    fn test_one_val_header(fuzz_key: &str, fuzz_val: &str) {
+        let (_, vec_httpheader_input, _) = data_test_header(fuzz_key, fuzz_val, 1);
+        let expected = HashMap::from([(
+            format!("x-{}-key-0", fuzz_key).to_string(),
+            One(format!("x-{}-val-0", fuzz_val).to_string()),
+        )]);
+        let tested = headers_to_json(&vec_httpheader_input);
+
+        assert_eq!(expected, tested);
+    }
+    #[rstest(fuzz_key, fuzz_val, case("basic", "basic"), case("basic", "🦄"))]
+    fn test_many_vals_header(fuzz_key: &str, fuzz_val: &str) {
+        let hdr_key = format!("x-{}-key-0", fuzz_key).to_string();
+        let hdr_val1 = format!("x-{}-val-0", fuzz_val).to_string();
+        let hdr_val2 = format!("x-{}-val-1", fuzz_val).to_string();
+
+        let vec_header_input = vec![
+            HttpHeader {
+                name: hdr_key.clone(),
+                value: hdr_val1.clone(),
+            },
+            HttpHeader {
+                name: hdr_key.clone(),
+                value: hdr_val2.clone(),
+            },
+        ];
+
+        let expected = HashMap::from([(hdr_key, Many(vec![hdr_val1, hdr_val2]))]);
+
+        let tested = headers_to_json(&vec_header_input);
+
+        assert_eq!(expected, tested);
+    }
+}

--- a/rust-connectors/sources/http/src/lib.rs
+++ b/rust-connectors/sources/http/src/lib.rs
@@ -24,9 +24,17 @@ pub struct HttpOpt {
     #[structopt(long = "header", alias = "headers")]
     pub headers: Vec<String>,
 
-    /// Response output format: body | full    
+    /// DEPRECATED: Response output parts: body | full
+    #[structopt(long, hidden(true))]
+    pub output_format: Option<String>,
+
+    /// Response output parts: body | full    
     #[structopt(long, default_value = "body")]
-    pub output_format: String,
+    pub output_parts: String,
+
+    /// Response output type: text | json    
+    #[structopt(long, default_value = "text")]
+    pub output_type: String,
 
     #[structopt(flatten)]
     #[schemars(flatten)]

--- a/rust-connectors/sources/http/tests/get-test-full-json-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-full-json-config.yaml
@@ -8,5 +8,6 @@ parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
   output_parts: full
+  output_type: json
   body: ''
   interval: 1

--- a/rust-connectors/sources/http/tests/get-test-full-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-full-json.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load '../../../utils/bats-helpers/bats-support/load'
+load '../../../utils/bats-helpers/bats-assert/load'
+
+setup() {
+    cargo build -p http-json-mock
+    ../../../target/debug/http-json-mock & disown
+    MOCK_PID=$!
+    FILE=$(mktemp --suffix .yaml)
+    cp ./tests/get-test-full-json-config.yaml $FILE
+    UUID=$(uuidgen)
+    TOPIC=${UUID}-topic
+
+    sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
+    IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
+    sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
+    fluvio connector create --config $FILE
+}
+
+teardown() {
+    fluvio connector delete $UUID
+    fluvio topic delete $TOPIC
+    kill $MOCK_PID
+}
+
+@test "http-connector-get-full-json-test" {
+    count=1
+    echo "Starting consumer on topic $TOPIC"
+    sleep 10
+
+    run fluvio consume -o 0 --end-offset 0 -d $TOPIC
+    assert_output --partial '"version": "HTTP/1.1",'
+
+    run fluvio consume -o 0 --end-offset 0 -d $TOPIC
+    assert_output --partial '"content-type": "text/plain;charset=utf-8"'
+
+    run fluvio consume -o 0 --end-offset 0 -d $TOPIC
+    assert_output --partial '"status_code": 200,'
+
+    run fluvio consume -o 1 --end-offset 1 -d $TOPIC
+    assert_output --partial '"body": {"Hello, Fluvio! - ' 
+}
+

--- a/rust-connectors/sources/http/tests/get-test-json-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-json-config.yaml
@@ -7,6 +7,6 @@ direction: source
 parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
-  output_parts: full
+  output_type: json
   body: ''
   interval: 1

--- a/rust-connectors/sources/http/tests/get-test-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-json.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+load '../../../utils/bats-helpers/bats-support/load'
+load '../../../utils/bats-helpers/bats-assert/load'
+
+setup() {
+    cargo build -p http-json-mock
+    ../../../target/debug/http-json-mock & disown
+    MOCK_PID=$!
+    FILE=$(mktemp --suffix .yaml)
+    cp ./tests/get-test-json-config.yaml $FILE
+    UUID=$(uuidgen)
+    TOPIC=${UUID}-topic
+
+    sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
+    IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
+    sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
+    fluvio connector create --config $FILE
+}
+
+teardown() {
+    fluvio connector delete $UUID
+    fluvio topic delete $TOPIC
+    kill $MOCK_PID
+}
+
+@test "http-connector-get-json-test" {
+    count=1
+    echo "Starting consumer on topic $TOPIC"
+    sleep 10
+
+    run fluvio consume -o 1 --end-offset 1 -d $TOPIC
+    assert_output --partial '{"body": {"Hello, Fluvio! - ' 
+}
+


### PR DESCRIPTION
Adding json output_type - originating issue #97 
Extending on previous #127 

**New Metadata**
```rust
    /// Response output type: text | json    
    #[structopt(long, default_value = "text")]
    pub output_type: String,
```
**Changed Metadata**
- output_format has been deprecated and advised as output_parts = body (default) | full
```rust
    /// Response output parts: body | full                                                                                                                           
    #[structopt(long, default_value = "body")]
    pub output_parts: String,
```

**Notes on Headers**
- We are not manipulating headers in any way in order to preserve the originals

**JSON Notes**
- Response body which itself is JSON is encoded into JSON String field "body" resulting to \ escapes
- If we require "fusing" or "joining" JSON under the "body" then that needs to be decided and added later
- Headers that have only one value are plain JSON "String"
- Headers that have multiple values are encoded into JSON Array e.g. set-cookie
- No type mapping on headers - it's all JSON typed "String" or JSON array "String" values.

**Tech Debt Impacted**
- version: dev impacts testing
https://github.com/infinyon/fluvio-connectors/issues/134

**To be potentially worked on separate PR**
- output_fields - status | head as mix-ins for output
- Separate formatter configuration from the actual record format in the interface
- "output_fuse" to opportunistically "fuse" same-type serialised format under "body" instead of encoding escaped String

**Matrix with four types/formats**

--output-parts body --output-type text
```
{"fact":"Unlike humans, cats are usually lefties. Studies indicate that their left paw is typically their dominant paw.","length":110}
```

--output-parts full --output-type text
```
HTTP/1.1 200 OK
server: nginx
date: Sat, 05 Feb 2022 12:13:46 GMT
content-type: application/json
transfer-encoding: chunked
connection: keep-alive
vary: Accept-Encoding
cache-control: no-cache, private
x-ratelimit-limit: 100
x-ratelimit-remaining: 99
access-control-allow-origin: *
set-cookie: XSRF-TOKEN=eyJpdiI6InA3cDd0SUZ3TGU4ZDV2WG5WYzlSS0E9PSIsInZhbHVlIjoiQ0FXZG9XMGpYbDFNc0U3OEFDbVBXcURPRjlBdHhFK3hpTkVIa3B1bjhBK3lPQ0l4NGY4d2tpcnRLZHVJZFk0Q21ROXE5U25UQXdSR3pQZXpObmpVZk4vVDZjOHQwQkFKYitCVlhRMldrK3NMZjkremExTy9uZjJwdUxoaGNQVk8iLCJtYWMiOiIzZmNmOTYyZWNlNmFiNjZmOTJhMDk4YzAxNjg1YWViMWY1ZmI5NTFjZWJjY2Y5YTM2NTI2NmEyOTIwNTg4MjEyIiwidGFnIjoiIn0%3D; expires=Sat, 05-Feb-2022 14:13:46 GMT; path=/; samesite=lax
set-cookie: cat_facts_session=eyJpdiI6ImZ0bXdic3l5Q2p0bllCYkErblhtM3c9PSIsInZhbHVlIjoiT1pZb1RWeEttVTRKcEhCUDhwNE1ZU0ZmQWxET3ZyemlpWWhZcmZBdUxUMGlTRWFEWkptV2gvbVlnbWxmbERJWFU0TG5RSFVNclNoaFJpRGJXM3JVQWVYUFdwbTJaL2NFRkd6cytGR295ZjIzNHZhdTl1bnVnZjFaaTZDYjVBRzMiLCJtYWMiOiI4NzU1MDg0NGFmODkwNDdhMjI4OTExOWNkMTQ4MjU3YzVkYjdkYzQwNDY5ODQ2MDViYmI3YmNiMDNhYmU3MTZlIiwidGFnIjoiIn0%3D; expires=Sat, 05-Feb-2022 14:13:46 GMT; path=/; httponly; samesite=lax
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff

{"fact":"When your cats rubs up against you, she is actually marking you as 'hers' with her scent. If your cat pushes his face against your head, it is a sign of acceptance and affection.","length":137}
```

--output-parts body --output-type json
```
{"body":"{\"fact\":\"The largest breed of cat is the Ragdoll with males weighing in at 1 5 to 20 lbs. The heaviest domestic cat on record was a neutered male tabby named Himmy from Queensland, Australia who weighed 46 lbs. 1 5 oz.\",\"length\":209}"}
```

--output-parts full --output-type json
```json
{"version":"HTTP/1.1","status_code":200,"status_string":"OK","headers":{"server":"nginx","transfer-encoding":"chunked","date":"Sat, 05 Feb 2022 12:15:01 GMT","x-content-type-options":"nosniff","access-control-allow-origin":"*","set-cookie":["XSRF-TOKEN=eyJpdiI6IlB5T1FVNXNDR3NvMlgrQzQ3TEJ4dGc9PSIsInZhbHVlIjoiKzRuckJrTU16SG9ycFk4L0w1QjYvdWQ1MDdJZGZZNURZSW9jQkN4RnlmMEcyMUo0TWVCSjE2SFJJblVrVWtTM05QOTE1VEdpOWlaTFlWMlFISEhSS0FRWThJMGNOaWpLOGFWTXVMRklWTzZ3dDJvSUxQTW5qeDdVNTYvV1M4ek8iLCJtYWMiOiJkOWE4NDQwZTIyOTdlZDAyMmU4OGQ5YTBkOWMzNjY1YmY0NDU5Y2RhOTZlNDg0NGI1YTdjMTE0ZTRkM2U2ZGJkIiwidGFnIjoiIn0%3D; expires=Sat, 05-Feb-2022 14:15:01 GMT; path=/; samesite=lax","cat_facts_session=eyJpdiI6IkNMWWxZLzFFL21wODdmanAyWjk0cFE9PSIsInZhbHVlIjoiNG1OTEZlKzhxVW9YaXBsbzl4TCtrVjJvQjBjWmdUYkg0VWtoVEgycVhGMWduUThNekNBQ0hxVFpCaG5PdHc3NnZsbWVhUHI2NU5Yem9mU1pxbk1CcDFLYUNIbkw1M2EzN1IrNTFlbDFkbG9YMjUyRUkrQnJ3OGR6NEdscVZpRnAiLCJtYWMiOiJlMWJlNTZmYzU1MmY2M2U1YjliMjEyMjFmZTcwM2FiOWI0MzEwM2M5YmM4ZDFiZjhkZTg5NDNmNGMwMmUzOTg5IiwidGFnIjoiIn0%3D; expires=Sat, 05-Feb-2022 14:15:01 GMT; path=/; httponly; samesite=lax"],"connection":"keep-alive","vary":"Accept-Encoding","cache-control":"no-cache, private","content-type":"application/json","x-ratelimit-limit":"100","x-xss-protection":"1; mode=block","x-frame-options":"SAMEORIGIN","x-ratelimit-remaining":"98"},"body":"{\"fact\":\"The first official cat show in the UK was organised at Crystal Palace in 1871.\",\"length\":78}"}
```