### PR TITLE
docs(http): CHANGELOG.md

### DIFF
--- a/rust-connectors/sources/http/CHANGELOG.md
+++ b/rust-connectors/sources/http/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Connector Change Log
+
+## http Version 0.2.X - UNRELEASED
+
+## http Version 0.2.0 - 2022-Feb-7
+* Feature json/body, json/full Response Record (#141)
+
+## http Version 0.1.1 - 2022-Jan-31
+* Feature text/full Response Record (#127)
+
+## http Version 0.1.0 - 2021-Nov-9
+* Initial version with text/body Response (default) Record


### PR DESCRIPTION
Release dates reflect when the PR was simply merged.

* 0.2.0 - output_parts = [ body (default) | full ] - output_type [ text (default) | json ]
* 0.1.1 - output_format (deprecated at 0.2.0) = [ body (default) | full ]
* 0.1.0 - only body as-is output