### PR TITLE
[Merged by Bors] - refactor: Remove dependency to fluvio_controlplane_metadata

### DIFF
--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -15,7 +15,6 @@ schemars = "0.8"
 structopt = "0.3"
 
 anyhow = "1.0.44"
-fluvio-controlplane-metadata = "0.13.1"
 fluvio-future = { version = "0.3.11", features = ["subscriber"] }
 fluvio = { version = "0.12", features = ["smartengine"] }
 flate2 = { version = "1.0" }

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 
 pub use fluvio::{consumer, Fluvio, PartitionConsumer, TopicProducer};
 
-use fluvio_controlplane_metadata::smartmodule::SmartModuleSpec;
+use fluvio::metadata::smartmodule::SmartModuleSpec;
 
 #[derive(StructOpt, Debug, JsonSchema, Clone)]
 #[structopt(settings = &[AppSettings::DeriveDisplayOrder])]


### PR DESCRIPTION
It is already reimported by the fluvio client

Mentioned in https://github.com/infinyon/fluvio-connectors/issues/168