### PR TITLE
chore(workflows): de-coupled build workflow

### DIFF
--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -1,0 +1,85 @@
+name: "Connector Container Builder"
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: 'Fluvio Connector to Build'
+        required: true
+        type: string
+
+jobs:
+  build_containers:
+    name: Build image ${{ inputs.name }} for ${{ matrix.rust-target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable]
+        rust-target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+    env:
+      RUSTV: ${{ matrix.rust }}
+      TARGET: ${{ matrix.rust-target }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: infinyon/fluvio-connectors      
+      # Building w/ QEMU for the arm64 support
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Inspect builder
+        run: |
+          echo "Name:      ${{ steps.buildx.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
+      # Download artifacts from build
+      - name: Download artifact - ${{ inputs.name }} - ${{ matrix.rust-target }}
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.name }}-${{ matrix.rust-target }}
+          # This is the directory the Makefile expects artifacts to live in
+          path: container-build
+
+      - name: Print container-build dir
+        run: |
+          ls container-build;
+          chmod +x ./container-build/${{ inputs.name }}
+          ./container-build/${{ inputs.name }} -h || true
+      # The build script will export the resulting image to
+      # /tmp/infinyon-fluvio-connector-${{ inputs.name }}-${{ matrix.rust-target }}.tar
+      - name: Build containers
+        if: inputs.name != 'test-connector'
+        env:
+          TARGET: ${{ matrix.rust-target }}
+          CONNECTOR_NAME: ${{ inputs.name }}
+          COMMIT_HASH: ${{ github.sha }}
+          # IMAGE_NAME: ${{ matrix.image-name }}
+        run: make official-containers
+
+      - name: Build Test-connector
+        if: inputs.name == 'test-connector'
+        env:
+          TARGET: ${{ matrix.rust-target }}
+          CONNECTOR_NAME: ${{ inputs.name }}
+          COMMIT_HASH: ${{ github.sha }}
+          DOCKERFILE_PATH: ./container-build/dockerfiles/test-connector/Dockerfile
+          # IMAGE_NAME: ${{ matrix.image-name }}
+        run: make official-containers
+      - name: Upload tarball as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: infinyon-fluvio-connector-${{ inputs.name }}-${{ matrix.rust-target }}.tar
+          path: /tmp/infinyon-fluvio-connector-${{ inputs.name }}-${{ matrix.rust-target }}.tar
+          retention-days: 1

--- a/.github/workflows/rust-builder.yml
+++ b/.github/workflows/rust-builder.yml
@@ -1,0 +1,72 @@
+name: "Fluvio Connector Builder"
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: 'Fluvio Connector to Build'
+        required: true
+        type: string
+#      serial:
+#        description: 'Unique Serial Identifier'
+#        required: true
+#        type: string
+#    outputs:
+#      artefacts_url:
+#        description: 'Built Artefacts'
+#        value: ${{ steps.bundle_builder.outputs.artefacts_url }}
+#        type: string
+
+jobs:
+  rust-builder:
+    name:  Build binary ${{ inputs.name }} for ${{ matrix.rust-target }} on (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust-target:
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+        rust: [stable]
+    env:
+      RUST_BACKTRACE: full
+      RUSTV: ${{ matrix.rust }}
+      TARGET: ${{ matrix.rust-target }}
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: infinyon/fluvio-connectors
+      - name: Set RELEASE mode
+        shell: bash
+        run: |
+          echo "RELEASE=true" | tee -a $GITHUB_ENV
+          echo "RELEASE_NAME=release" | tee -a $GITHUB_ENV
+          echo "RUST_BIN_DIR=target/${{ matrix.rust-target }}/release" | tee -a $GITHUB_ENV
+      - name: Print env
+        run: |
+          echo "RUST_BIN_DIR = ${{ env.RUST_BIN_DIR }} "
+      - name: Install Rust ${{ matrix.rust }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          target: ${{ matrix.rust-target }}
+      - name: Install zig
+        run: ./actions/zig-install.sh ${{ matrix.os }}
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.os }}-${{ matrix.rust-target }}-${{ inputs.name }}
+      - name: Build
+        env:
+          CONNECTOR_NAME: ${{ inputs.name }}
+        run: make build
+
+      # Upload artifacts
+      - name: Upload artifact - ${{ inputs.name }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.name }}-${{ matrix.rust-target }}
+          path: ${{ env.RUST_BIN_DIR }}/${{ inputs.name }}
+          retention-days: 1


### PR DESCRIPTION
Using the new Github "Reusable Workflow" feature to de-couple workflow logic

**I've de-coupled:**

* rust-builder.yml - build rust binary and
* docker-builder.yml - docker build

So these can be re-used for both clean connector release off monorepo and CI

We can dynamically scope in CI the individual connectors after this much easier with [paths-filter](https://github.com/dorny/paths-filter)

e.g. re-use:
```yaml
on:
  workflow_dispatch:
    inputs:
      name:
        description: 'Rust Connector'
        required: true
        type: choice
        options:
          - http
          - mqtt

jobs:
      
  build:
    uses: infinyon/fluvio-connectors/.github/workflows/rust-builder.yml@main
    with:
      name: ${{ github.event.inputs.name }}

  docker-build:
    uses: infinyon/fluvio-connectors/.github/workflows/docker-builder.yml@main
    needs: build
    with:
      name: ${{ github.event.inputs.name }}

  release:
    runs-on: ubuntu-latest
    needs: docker-build
   ... ties in the artifacts from previous steps and release ..
```

The build and docker-build via de-coupled workflow will create their own matrixes as needed