### PR TITLE
[Merged by Bors] - Use extra parameters in connector smartmodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,23 +1019,24 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa7c3188913c2d11a361e0431e135742372a2709a99b103e79758e11a0a797e"
+checksum = "7901fbba05decc537080b07cb3f1cadf53be7b7602ca8255786288a8692ae29a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29285f70fd396a8f64455a15a6e1d390322e4a5f5186de513141313211b0a23e"
+checksum = "37ba1b45d243a4a28e12d26cd5f2507da74e77c45927d40de8b6ffbf088b46b5"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "log",
  "regalloc2",
@@ -1045,33 +1046,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057eac2f202ec95aebfd8d495e88560ac085f6a415b3c6c28529dc5eb116a141"
+checksum = "54cc30032171bf230ce22b99c07c3a1de1221cb5375bd6dbe6dbe77d0eed743c"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d93869efd18874a9341cfd8ad66bcb08164e86357a694a0e939d29e87410b9"
+checksum = "a23f2672426d2bb4c9c3ef53e023076cfc4d8922f0eeaebaf372c92fae8b5c69"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e34bd7a1fefa902c90a921b36323f17a398b788fa56a75f07a29d83b6e28808"
+checksum = "886c59a5e0de1f06dbb7da80db149c75de10d5e2caca07cdd9fef8a5918a6336"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457018dd2d6ee300953978f63215b5edf3ae42dbdf8c7c038972f10394599f72"
+checksum = "ace74eeca11c439a9d4ed1a5cb9df31a54cd0f7fbddf82c8ce4ea8e9ad2a8fe0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1080,10 +1081,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-native"
-version = "0.84.0"
+name = "cranelift-isle"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba027cc41bf1d0eee2ddf16caba2ee1be682d0214520fff0129d2c6557fda89"
+checksum = "db1ae52a5cc2cad0d86fdd3dcb16b7217d2f1e65ab4f5814aa4f014ad335fa43"
+
+[[package]]
+name = "cranelift-native"
+version = "0.85.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadcfb7852900780d37102bce5698bcd401736403f07b52e714ff7a180e0e22f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1092,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.84.0"
+version = "0.85.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b17639ced10b9916c9be120d38c872ea4f9888aa09248568b10056ef0559bfa"
+checksum = "c84e3410960389110b88f97776f39f6d2c8becdaa4cd59e390e6b76d9d0e7190"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1395,7 +1402,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "schemars",
  "serde_json",
  "structopt",
@@ -1559,12 +1566,50 @@ dependencies = [
  "event-listener",
  "fluvio-compression",
  "fluvio-dataplane-protocol",
- "fluvio-future",
+ "fluvio-future 0.3.18",
+ "fluvio-protocol",
+ "fluvio-sc-schema",
+ "fluvio-socket 0.11.5",
+ "fluvio-spu-schema 0.9.4",
+ "fluvio-types",
+ "futures-util",
+ "once_cell",
+ "pin-project-lite 0.2.9",
+ "semver 1.0.12",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae5bad5447007ac26627fd3eee8fd6d4b866a4396eff86d699b0afc9ede7d8d"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-rwlock",
+ "async-trait",
+ "base64 0.13.0",
+ "built",
+ "bytes",
+ "cfg-if 1.0.0",
+ "derive_builder",
+ "dirs",
+ "event-listener",
+ "fluvio-compression",
+ "fluvio-dataplane-protocol",
+ "fluvio-future 0.4.1",
  "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-smartengine",
- "fluvio-socket",
- "fluvio-spu-schema",
+ "fluvio-socket 0.12.0",
+ "fluvio-spu-schema 0.10.0",
  "fluvio-types",
  "futures-util",
  "once_cell",
@@ -1599,14 +1644,16 @@ dependencies = [
  "anyhow",
  "bytesize",
  "flate2",
- "fluvio",
- "fluvio-future",
+ "fluvio 0.13.0",
+ "fluvio-future 0.3.18",
+ "fluvio-spu-schema 0.10.0",
  "humantime",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "structopt",
+ "thiserror",
  "tokio",
  "tokio-stream",
 ]
@@ -1620,7 +1667,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "fluvio-dataplane-protocol",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "fluvio-protocol",
  "fluvio-stream-model",
  "fluvio-types",
@@ -1642,7 +1689,7 @@ dependencies = [
  "crc32c",
  "eyre",
  "fluvio-compression",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "fluvio-protocol",
  "fluvio-types",
  "flv-util",
@@ -1669,7 +1716,31 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "log",
- "nix 0.23.1",
+ "openssl",
+ "openssl-sys",
+ "pin-project",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "fluvio-future"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daeda55da0ea44724a8aafc8b6af6d0ec08629df22b0200da06f7467008349a0"
+dependencies = [
+ "async-io",
+ "async-net",
+ "async-std",
+ "async-trait",
+ "cfg-if 1.0.0",
+ "fluvio-wasm-timer",
+ "futures-lite",
+ "futures-util",
+ "log",
+ "nix",
  "openssl",
  "openssl-sys",
  "pin-project",
@@ -1693,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c875b24392b835610a0e8c620d11e696014bd106f48a9759bbd080bd1f25d4dd"
 dependencies = [
  "bytes",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "fluvio-protocol-derive",
  "tokio-util 0.7.3",
  "tracing",
@@ -1730,16 +1801,17 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.2.11"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21880e49ff824b7881c6776fa0e4af2d24e90b861e2021878caf0d677de0825"
+checksum = "d3dd0bb5d103a022243a21cc3be50e94ec2f2d71d4f60b36c267b93e45c2920a"
 dependencies = [
  "anyhow",
  "fluvio-dataplane-protocol",
- "fluvio-future",
- "fluvio-spu-schema",
+ "fluvio-future 0.4.1",
+ "fluvio-spu-schema 0.10.0",
  "futures-util",
- "nix 0.24.1",
+ "nix",
+ "thiserror",
  "tracing",
  "wasmtime",
 ]
@@ -1778,7 +1850,30 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "event-listener",
- "fluvio-future",
+ "fluvio-future 0.3.18",
+ "fluvio-protocol",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.3",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-socket"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e03cddb6830ab51fa84352a6a0592c0c8e06c32cc4b4d9af90e33125fcff6d"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-trait",
+ "bytes",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "fluvio-future 0.4.1",
  "fluvio-protocol",
  "futures-util",
  "once_cell",
@@ -1794,6 +1889,22 @@ name = "fluvio-spu-schema"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a300a9e13672016511b71d3046c061fcfae2f66b48d5540decba7965b4975d4c"
+dependencies = [
+ "bytes",
+ "flate2",
+ "fluvio-dataplane-protocol",
+ "fluvio-protocol",
+ "log",
+ "serde",
+ "static_assertions",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-spu-schema"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4904b99254c7f7ec5e8b7d5518116e13ec091f8e2f8d8b630b2d4166e9c5b03"
 dependencies = [
  "bytes",
  "flate2",
@@ -1822,7 +1933,7 @@ name = "fluvio-syslog"
 version = "0.2.0"
 dependencies = [
  "cfg-if 1.0.0",
- "fluvio",
+ "fluvio 0.12.14",
  "futures-util",
  "notify",
  "serde",
@@ -2266,7 +2377,7 @@ version = "0.3.0"
 dependencies = [
  "fluvio-connectors-common",
  "fluvio-dataplane-protocol",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "humantime",
  "reqwest",
  "rstest",
@@ -2526,7 +2637,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "kafka",
  "rdkafka",
  "schemars",
@@ -2543,7 +2654,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "kafka",
  "schemars",
  "serde",
@@ -2757,7 +2868,7 @@ dependencies = [
  "anyhow",
  "async-global-executor",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "rumqttc",
  "rustls 0.20.6",
  "rustls-native-certs 0.6.2",
@@ -2787,19 +2898,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -3191,9 +3289,9 @@ dependencies = [
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio",
+ "fluvio 0.12.14",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "fluvio-model-postgres",
  "once_cell",
  "postgres-protocol 0.6.1",
@@ -3221,9 +3319,9 @@ dependencies = [
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio",
+ "fluvio 0.13.0",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "fluvio-model-postgres",
  "once_cell",
  "postgres-protocol 0.6.1",
@@ -3487,9 +3585,9 @@ checksum = "f4ed1d73fb92eba9b841ba2aef69533a060ccc0d3ec71c90aeda5996d4afb7a9"
 
 [[package]]
 name = "regalloc2"
-version = "0.1.3"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904196c12c9f55d3aea578613219f493ced8e05b3d0c6a42d11cb4142d8b4879"
+checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
 dependencies = [
  "fxhash",
  "log",
@@ -4094,7 +4192,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "fluvio-connectors-common",
- "fluvio-future",
+ "fluvio-future 0.3.18",
  "reqwest",
  "schemars",
  "serde",
@@ -4984,18 +5082,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdd1101bdfa0414a19018ec0a091951a20b695d4d04f858d49f6c4cc53cd8dd"
+checksum = "e76e2b2833bb0ece666ccdbed7b71b617d447da11f1bb61f4f2bab2648f745ee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5027,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79da81ed0724392948ad7a0fb5088ff1bd15fa937356c8c037c6b1c8b5473cde"
+checksum = "743a9f142d93318262d7e1fe329394ff2e8f86a1df45ae5e4f0eedba215ca5ce"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -5047,9 +5145,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e78edcfb0daa9a9579ac379d00e2d5a5b2a60c0d653c8c95e8412f2166acb9"
+checksum = "5dc0f80afa1ce97083a7168e6b6948d015d6237369e9f4a511d38c9c4ac8fbb9"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5069,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4201389132ec467981980549574b33fc70d493b40f2c045c8ce5c7b54fbad97e"
+checksum = "0816d9365196f1f447060087e0f87239ccded830bd54970a1168b0c9c8e824c9"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -5089,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba6777a84b44f9a384b5c9d511ae3d86534438b7e25d928b8e8e858ecad5df2"
+checksum = "715afdb87a3bcf1eae3f098c742d650fb783abdb8a7ca87076ea1cabecabea5d"
 dependencies = [
  "cc",
  "rustix",
@@ -5100,9 +5198,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1587ca7752d00862faa540d00fd28e5ccf1ac61ba19756449193f1153cb2b127"
+checksum = "5c687f33cfa0f89ec1646929d0ff102087052cf9f0d15533de56526b0da0d1b3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5127,9 +5225,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27233ab6c8934b23171c64f215f902ef19d18c1712b46a0674286d1ef28d5dd"
+checksum = "b252d1d025f94f3954ba2111f12f3a22826a0764a11c150c2d46623115a69e27"
 dependencies = [
  "lazy_static",
  "object",
@@ -5138,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d3b0b8f13db47db59d616e498fe45295819d04a55f9921af29561827bdb816"
+checksum = "ace251693103c9facbbd7df87a29a75e68016e48bc83c09133f2fda6b575e0ab"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -5165,9 +5263,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1630d9dca185299bec7f557a7e73b28742fe5590caf19df001422282a0a98ad1"
+checksum = "d129b0487a95986692af8708ffde9c50b0568dcefd79200941d475713b4f40bb"
 dependencies = [
  "cranelift-entity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
 
 [[package]]
 name = "dynamodb-sink"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -1549,44 +1549,6 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.12.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0cab7f75c6163d40a37263cd5bb0c611211e971e2b47b198fa2376d5509ea3"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-rwlock",
- "async-trait",
- "base64 0.13.0",
- "built",
- "bytes",
- "cfg-if 1.0.0",
- "derive_builder",
- "dirs",
- "event-listener",
- "fluvio-compression",
- "fluvio-dataplane-protocol",
- "fluvio-future 0.3.18",
- "fluvio-protocol",
- "fluvio-sc-schema",
- "fluvio-socket 0.11.5",
- "fluvio-spu-schema 0.9.4",
- "fluvio-types",
- "futures-util",
- "once_cell",
- "pin-project-lite 0.2.9",
- "semver 1.0.12",
- "serde",
- "serde_json",
- "siphasher",
- "thiserror",
- "tokio",
- "toml",
- "tracing",
-]
-
-[[package]]
-name = "fluvio"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae5bad5447007ac26627fd3eee8fd6d4b866a4396eff86d699b0afc9ede7d8d"
@@ -1608,8 +1570,8 @@ dependencies = [
  "fluvio-protocol",
  "fluvio-sc-schema",
  "fluvio-smartengine",
- "fluvio-socket 0.12.0",
- "fluvio-spu-schema 0.10.0",
+ "fluvio-socket",
+ "fluvio-spu-schema",
  "fluvio-types",
  "futures-util",
  "once_cell",
@@ -1644,9 +1606,9 @@ dependencies = [
  "anyhow",
  "bytesize",
  "flate2",
- "fluvio 0.13.0",
+ "fluvio",
  "fluvio-future 0.3.18",
- "fluvio-spu-schema 0.10.0",
+ "fluvio-spu-schema",
  "humantime",
  "schemars",
  "serde",
@@ -1707,17 +1669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e2d1fad8e412d44c516add2349a34f6d71d9279b108c8e012325ab17fcbf982"
 dependencies = [
  "async-io",
- "async-net",
  "async-std",
- "async-trait",
  "cfg-if 1.0.0",
  "fluvio-test-derive",
  "fluvio-wasm-timer",
  "futures-lite",
- "futures-util",
  "log",
- "openssl",
- "openssl-sys",
  "pin-project",
  "thiserror",
  "tracing",
@@ -1808,7 +1765,7 @@ dependencies = [
  "anyhow",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.1",
- "fluvio-spu-schema 0.10.0",
+ "fluvio-spu-schema",
  "futures-util",
  "nix",
  "thiserror",
@@ -1840,29 +1797,6 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c35259517081cd708d7b13d7afe1728d77f983e78b029924e8bd51ebfe0f219"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-trait",
- "bytes",
- "cfg-if 1.0.0",
- "event-listener",
- "fluvio-future 0.3.18",
- "fluvio-protocol",
- "futures-util",
- "once_cell",
- "pin-project",
- "thiserror",
- "tokio",
- "tokio-util 0.7.3",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-socket"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e03cddb6830ab51fa84352a6a0592c0c8e06c32cc4b4d9af90e33125fcff6d"
@@ -1881,22 +1815,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.3",
- "tracing",
-]
-
-[[package]]
-name = "fluvio-spu-schema"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a300a9e13672016511b71d3046c061fcfae2f66b48d5540decba7965b4975d4c"
-dependencies = [
- "bytes",
- "flate2",
- "fluvio-dataplane-protocol",
- "fluvio-protocol",
- "log",
- "serde",
- "static_assertions",
  "tracing",
 ]
 
@@ -1933,7 +1851,7 @@ name = "fluvio-syslog"
 version = "0.2.0"
 dependencies = [
  "cfg-if 1.0.0",
- "fluvio 0.12.14",
+ "fluvio",
  "futures-util",
  "notify",
  "serde",
@@ -2373,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "http-source"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fluvio-connectors-common",
  "fluvio-dataplane-protocol",
@@ -2633,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-sink"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "fluvio-connectors-common",
@@ -2863,7 +2781,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mqtt-source"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-global-executor",
@@ -3283,13 +3201,13 @@ dependencies = [
 
 [[package]]
 name = "postgres-sink"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio 0.12.14",
+ "fluvio",
  "fluvio-connectors-common",
  "fluvio-future 0.3.18",
  "fluvio-model-postgres",
@@ -3312,14 +3230,14 @@ dependencies = [
 
 [[package]]
 name = "postgres-source"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "adaptive_backoff",
  "bytes",
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio 0.13.0",
+ "fluvio",
  "fluvio-connectors-common",
  "fluvio-future 0.3.18",
  "fluvio-model-postgres",
@@ -4188,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "slack-sink"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "fluvio-connectors-common",

--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -19,12 +19,14 @@ structopt = "0.3"
 
 anyhow = "1.0.56"
 fluvio-future = { version = "0.3.15", features = ["subscriber"] }
-fluvio = { version = "0.12", features = ["smartengine"] }
+fluvio = { version = "0.13", features = ["smartengine"] }
 flate2 = { version = "1.0" }
 tokio-stream = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 humantime = "2.1.0"
 bytesize = "1.1.0"
+thiserror = "1.0.31"
+fluvio-spu-schema = "0.10.0"
 
 [dev-dependencies]
 serde_yaml = "0.8.18"

--- a/rust-connectors/common/src/error.rs
+++ b/rust-connectors/common/src/error.rs
@@ -1,0 +1,11 @@
+use std::{convert::Infallible, io::Error as IoError};
+
+#[derive(thiserror::Error, Debug)]
+pub enum CliError {
+    #[error(transparent)]
+    IoError(#[from] IoError),
+    #[error("Invalid argument: {0}")]
+    InvalidArg(String),
+    #[error("Unexpected Infallible error")]
+    Infallible(#[from] Infallible),
+}

--- a/rust-connectors/common/src/lib.rs
+++ b/rust-connectors/common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod fluvio {
     pub use fluvio::{FluvioError, PartitionConsumer, RecordKey, TopicProducer};
 }
 
+pub(crate) mod error;
 pub mod opt;
 
 pub fn git_hash_version() -> &'static str {

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -125,7 +125,7 @@ pub struct CommonSmartModuleOpt {
     /// It only accepts one key:value pair. In order to pass multiple pairs, call this option multiple times.
     ///
     /// Example:
-    /// --smartmodule-parameters key1:value --smartmodyle-parameters key2:value
+    /// --smartmodule-parameters key1:value --smartmodule-parameters key2:value
     #[structopt(
         long,
         parse(try_from_str = parse_key_val),

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -105,7 +105,7 @@ pub struct CommonSmartModuleOpt {
     #[structopt(long, requires = "aggregate_group")]
     pub aggregate_initial_value: Option<String>,
 
-    /// Path of aggregate smartmodule used as a pre-produce step
+    /// Path of smartmodule used as a pre-produce step
     /// if using source connector. If using sink connector this smartmodule
     /// will be used in consumer.    
     ///
@@ -168,6 +168,7 @@ impl CommonConnectorOpt {
         let config_builder = TopicProducerConfigBuilder::default();
         let params = self.smartmodule_parameters();
 
+        println!("{:?}", params);
         // Linger
         let config_builder = if let Some(linger) = self.producer_common.producer_linger {
             config_builder.linger(linger)

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -168,7 +168,6 @@ impl CommonConnectorOpt {
         let config_builder = TopicProducerConfigBuilder::default();
         let params = self.smartmodule_parameters();
 
-        println!("{:?}", params);
         // Linger
         let config_builder = if let Some(linger) = self.producer_common.producer_linger {
             config_builder.linger(linger)

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -120,7 +120,12 @@ pub struct CommonSmartModuleOpt {
     pub smart_module: Option<String>,
 
     /// (Optional) Extra input parameters passed to the smartmodule module.
-    /// They should be passed using key=value format
+    /// They should be passed using key:value format.
+    ///
+    /// It only accepts one key:value pair. In order to pass multiple pairs, call this option multiple times.
+    ///
+    /// Example:
+    /// --smartmodule-parameters key1:value --smartmodyle-parameters key2:value
     #[structopt(
         long,
         parse(try_from_str = parse_key_val),
@@ -131,8 +136,8 @@ pub struct CommonSmartModuleOpt {
 }
 
 fn parse_key_val(s: &str) -> Result<(String, String), CliError> {
-    let pos = s.find('=').ok_or_else(|| {
-        CliError::InvalidArg(format!("invalid KEY=value: no `=` found in `{}`", s))
+    let pos = s.find(':').ok_or_else(|| {
+        CliError::InvalidArg(format!("invalid KEY=value: no `:` found in `{}`", s))
     })?;
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -1,8 +1,9 @@
 use anyhow::Context;
 use bytesize::ByteSize;
+use fluvio_spu_schema::server::stream_fetch::SmartModuleContextData;
 use humantime::parse_duration;
 use schemars::{schema_for, JsonSchema};
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 use tokio_stream::Stream;
@@ -16,6 +17,8 @@ pub use fluvio::{
     Compression, ConsumerConfig, Fluvio, FluvioError, PartitionConsumer, TopicProducer,
     TopicProducerConfigBuilder,
 };
+
+use crate::error::CliError;
 
 #[derive(StructOpt, Debug, JsonSchema, Clone, Default)]
 #[structopt(settings = &[AppSettings::DeriveDisplayOrder])]
@@ -55,44 +58,84 @@ pub struct CommonConsumerOpt {
 #[derive(StructOpt, Debug, JsonSchema, Clone, Default)]
 pub struct CommonSmartModuleOpt {
     /// Path of filter smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.
     ///
     /// If the value is not a path to a file, it will be used
     /// to lookup a SmartModule by name
-    #[structopt(long, group("smartmodule"))]
+    #[structopt(long, group("smartmodule_group"))]
     pub filter: Option<String>,
 
     /// Path of filter_map smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.
     ///
     /// If the value is not a path to a file, it will be used
     /// to lookup a SmartModule by name
-    #[structopt(long, group("smartmodule"))]
+    #[structopt(long, group("smartmodule_group"))]
     pub filter_map: Option<String>,
 
     /// Path of map smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.
     ///
     /// If the value is not a path to a file, it will be used
     /// to lookup a SmartModule by name
-    #[structopt(long, group("smartmodule"))]
+    #[structopt(long, group("smartmodule_group"))]
     pub map: Option<String>,
 
     /// Path of arraymap smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.
     ///
     /// If the value is not a path to a file, it will be used
     /// to lookup a SmartModule by name
-    #[structopt(long, group("smartmodule"), alias = "arraymap")]
+    #[structopt(long, group("smartmodule_group"), alias = "arraymap")]
     pub array_map: Option<String>,
 
     /// Path of aggregate smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.
     ///
     /// If the value is not a path to a file, it will be used
     /// to lookup a SmartModule by name
-    #[structopt(long, group("smartmodule"))]
+    #[structopt(long, group("aggregate_group"), group("smartmodule_group"))]
     pub aggregate: Option<String>,
 
-    #[structopt(long)]
+    #[structopt(long, requires = "aggregate_group")]
     pub aggregate_initial_value: Option<String>,
+
+    /// Path of aggregate smartmodule used as a pre-produce step
+    /// if using source connector. If using sink connector this smartmodule
+    /// will be used in consumer.    
+    /// 
+    /// If the value is not a path to a file, it will be used
+    /// to lookup a SmartModule by name
+    #[structopt(
+        long,
+        alias = "smartmodule",
+        group("aggregate_group"),
+        group("smartmodule_group")
+    )]
+    pub smart_module: Option<String>,
+
+    /// (Optional) Extra input parameters passed to the smartmodule module.
+    /// They should be passed using key=value format
+    #[structopt(
+        long, 
+        parse(try_from_str = parse_key_val), 
+        requires = "smartmodule_group", 
+        number_of_values = 1
+    )]
+    pub smartmodule_parameters: Option<Vec<(String, String)>>,
 }
 
+fn parse_key_val(s: &str) -> Result<(String, String), CliError> {
+    let pos = s.find('=').ok_or_else(|| {
+        CliError::InvalidArg(format!("invalid KEY=value: no `=` found in `{}`", s))
+    })?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
 #[derive(StructOpt, Debug, JsonSchema, Clone, Default)]
 pub struct CommonProducerOpt {
     /// Time to wait before sending
@@ -118,6 +161,7 @@ impl CommonConnectorOpt {
         let fluvio = fluvio::Fluvio::connect().await?;
         self.ensure_topic_exists().await?;
         let config_builder = TopicProducerConfigBuilder::default();
+        let params = self.smartmodule_parameters();
 
         // Linger
         let config_builder = if let Some(linger) = self.producer_common.producer_linger {
@@ -146,33 +190,45 @@ impl CommonConnectorOpt {
             .await?;
 
         let producer = match (
+            &self.smartmodule_common.smart_module,
             &self.smartmodule_common.filter,
             &self.smartmodule_common.filter_map,
             &self.smartmodule_common.map,
             &self.smartmodule_common.array_map,
             &self.smartmodule_common.aggregate,
         ) {
-            (Some(filter_path), _, _, _, _) => {
+            (Some(smartmodule_name), _, _, _, _, _) => {
+                let context = match &self.smartmodule_common.aggregate_initial_value {
+                    Some(initial_value) => {
+                        SmartModuleContextData::Aggregate{accumulator: initial_value.as_bytes().to_vec()}
+                    }
+                    None => SmartModuleContextData::None,
+                };
+
+                let data = self.get_smartmodule(smartmodule_name, &fluvio).await?;
+                producer.with_smartmodule(data, params, context)?
+            }
+            (_, Some(filter_path), _, _, _, _) => {
                 let data = self.get_smartmodule(filter_path, &fluvio).await?;
-                producer.with_filter(data, Default::default())?
+                producer.with_filter(data, params)?
             }
-            (_, Some(filter_map_path), _, _, _) => {
+            (_, _, Some(filter_map_path), _, _, _) => {
                 let data = self.get_smartmodule(filter_map_path, &fluvio).await?;
-                producer.with_filter_map(data, Default::default())?
+                producer.with_filter_map(data, params)?
             }
-            (_, _, Some(map_path), _, _) => {
+            (_, _, _, Some(map_path), _, _) => {
                 let data = self.get_smartmodule(map_path, &fluvio).await?;
-                producer.with_map(data, Default::default())?
+                producer.with_map(data, params)?
             }
-            (_, _, _, Some(array_map_path), _) => {
+            (_, _, _, _, Some(array_map_path), _) => {
                 let data = self.get_smartmodule(array_map_path, &fluvio).await?;
-                producer.with_array_map(data, Default::default())?
+                producer.with_array_map(data, params)?
             }
-            (_, _, _, _, Some(aggregate)) => {
+            (_, _, _, _, _, Some(aggregate)) => {
                 let data = self.get_smartmodule(aggregate, &fluvio).await?;
                 let initial = self.get_aggregate_initial_value(&fluvio).await?;
                 self.get_aggregate_initial_value(&fluvio).await?;
-                producer.with_aggregate(data, Default::default(), initial)?
+                producer.with_aggregate(data, params, initial)?
             }
             _ => producer,
         };
@@ -219,6 +275,7 @@ impl CommonConnectorOpt {
         &self,
     ) -> anyhow::Result<impl Stream<Item = Result<Record, ErrorCode>>> {
         let fluvio = fluvio::Fluvio::connect().await?;
+        let params = self.smartmodule_parameters().into();
         let wasm_invocation: Option<SmartModuleInvocation> = match (
             &self.smartmodule_common.filter,
             &self.smartmodule_common.map,
@@ -230,7 +287,7 @@ impl CommonConnectorOpt {
                 Some(SmartModuleInvocation {
                     wasm: SmartModuleInvocationWasm::adhoc_from_bytes(&data)?,
                     kind: SmartModuleKind::Filter,
-                    params: Default::default(),
+                    params,
                 })
             }
             (_, Some(map_path), _, _) => {
@@ -238,7 +295,7 @@ impl CommonConnectorOpt {
                 Some(SmartModuleInvocation {
                     wasm: SmartModuleInvocationWasm::adhoc_from_bytes(&data)?,
                     kind: SmartModuleKind::Map,
-                    params: Default::default(),
+                    params,
                 })
             }
             (_, _, Some(array_map_path), _) => {
@@ -246,7 +303,7 @@ impl CommonConnectorOpt {
                 Some(SmartModuleInvocation {
                     wasm: SmartModuleInvocationWasm::adhoc_from_bytes(&data)?,
                     kind: SmartModuleKind::ArrayMap,
-                    params: Default::default(),
+                    params,
                 })
             }
             (_, _, _, Some(filter_map_path)) => {
@@ -254,7 +311,7 @@ impl CommonConnectorOpt {
                 Some(SmartModuleInvocation {
                     wasm: SmartModuleInvocationWasm::adhoc_from_bytes(&data)?,
                     kind: SmartModuleKind::FilterMap,
-                    params: Default::default(),
+                    params,
                 })
             }
             _ => None,
@@ -269,6 +326,14 @@ impl CommonConnectorOpt {
 }
 
 impl CommonConnectorOpt {
+    fn smartmodule_parameters(&self) -> BTreeMap<String, String> {
+        self.smartmodule_common
+            .smartmodule_parameters
+            .clone()
+            .map(|params| params.into_iter().collect())
+            .unwrap_or_default()
+    }
+
     pub fn enable_logging(&self) {
         if std::env::var("RUST_LOG").is_err() {
             std::env::set_var("RUST_LOG", "info")

--- a/rust-connectors/sinks/dynamodb/CHANGELOG.md
+++ b/rust-connectors/sinks/dynamodb/CHANGELOG.md
@@ -1,3 +1,6 @@
 # DynamoDb Connector Change Log
 
+## dynamodb Version 0.2.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## Dynamo Version 0.1.0 - UNRELEASED

--- a/rust-connectors/sinks/dynamodb/Cargo.toml
+++ b/rust-connectors/sinks/dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynamodb-sink"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sinks/kafka/CHANGELOG.md
+++ b/rust-connectors/sinks/kafka/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Kafka Sink Change Log
 
+## kafka-sink Version 0.2.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## kafka-sink Version 0.1.0 - UNRELEASED

--- a/rust-connectors/sinks/kafka/Cargo.toml
+++ b/rust-connectors/sinks/kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-sink"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sinks/postgres/CHANGELOG.md
+++ b/rust-connectors/sinks/postgres/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 # Connector Change Log
 
+## postgres Version 0.2.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## postgres Version 0.1.0 - 2022-Feb-11
 * Initial Postgres Sink Connector ([PR #126](https://github.com/infinyon/fluvio-connectors/pull/126))

--- a/rust-connectors/sinks/postgres/Cargo.toml
+++ b/rust-connectors/sinks/postgres/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "postgres-sink"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
 tracing = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1" }
-fluvio = { version = "0.12" }
+fluvio = { version = "0.13" }
 fluvio-future = { version = "0.3", features = ["subscriber"] }
 fluvio-connectors-common = { path = "../../common", features = ["sink"]}
 fluvio-model-postgres = { path = "../../models/fluvio-model-postgres" }

--- a/rust-connectors/sinks/slack/CHANGELOG.md
+++ b/rust-connectors/sinks/slack/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Slack Connector Change Log
 
-## http Version 0.1.0 - UNRELEASED
+## slack Version 0.2.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
+## slack Version 0.1.0 - UNRELEASED

--- a/rust-connectors/sinks/slack/Cargo.toml
+++ b/rust-connectors/sinks/slack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-sink"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sources/http/CHANGELOG.md
+++ b/rust-connectors/sources/http/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Connector Change Log
+## http Version 0.3.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
 
-## http Version 0.3.0 - UNRELEASED
+## http Version 0.3.0 - 2022-Jul-07
 * `interval` field uses human readable values, "1s", "20ms", etc. ([PR #274](https://github.com/infinyon/fluvio-connectors/pull/274))
 * `source-linger` field uses human readable values, "1s", "20ms", etc. ([PR #273](https://github.com/infinyon/fluvio-connectors/pull/273))
 

--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-source"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Fluvio connector that fetches data from HTTP endpoints"
 edition = "2021"
 

--- a/rust-connectors/sources/kafka/CHANGELOG.md
+++ b/rust-connectors/sources/kafka/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Kafka Source Connector Change Log
 
+## kafka Version 0.2.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## kafka-source version 0.1.0 - UNRELEASED

--- a/rust-connectors/sources/mqtt/CHANGELOG.md
+++ b/rust-connectors/sources/mqtt/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Connector Change Log
 
+## mqtt Version 0.3.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## mqtt Version 0.2.0 - UNRELEASED
 * Add TLS Support for MQTT Connector ([PR #179](https://github.com/infinyon/fluvio-connectors/pull/179))
 

--- a/rust-connectors/sources/mqtt/Cargo.toml
+++ b/rust-connectors/sources/mqtt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt-source"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 fluvio-connectors-common = { path = "../../common" }
-fluvio-future = { version = "0.3.15", features = ["subscriber"] }
+fluvio-future = { version = "0.3.15", features = ["subscriber", "timer"] }
 uuid = { version = "1.1", features = ["v4"] }
 
 thiserror = "1.0.29"

--- a/rust-connectors/sources/postgres/CHANGELOG.md
+++ b/rust-connectors/sources/postgres/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Connector Change Log
 
+## postgres Version 0.3.1 - UNRELEASED
+* Added support to smartmodule-parameters and smartmodule without explicit type. ([PR #287](https://github.com/infinyon/fluvio-connectors/pull/287)
+
 ## postgres Version 0.1.0 - 2022-Feb-11
 * Initial Source Connector ([PR #116](https://github.com/infinyon/fluvio-connectors/pull/116))
 * Retry postgres connection in case of failure ([PR #139](https://github.com/infinyon/fluvio-connectors/pull/139))

--- a/rust-connectors/sources/postgres/Cargo.toml
+++ b/rust-connectors/sources/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-source"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 [[bin]]
 name = "postgres-source"
@@ -12,7 +12,7 @@ tracing = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1" }
 fluvio = { version = "0.13" }
-fluvio-future = { version = "0.3", features = ["subscriber"] }
+fluvio-future = { version = "0.3", features = ["subscriber", "timer"] }
 fluvio-connectors-common = { path = "../../common", features = ["source"]}
 fluvio-model-postgres = { path = "../../models/fluvio-model-postgres" }
 bytes = "1"

--- a/rust-connectors/sources/postgres/Cargo.toml
+++ b/rust-connectors/sources/postgres/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin/main.rs"
 tracing = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1" }
-fluvio = { version = "0.12" }
+fluvio = { version = "0.13" }
 fluvio-future = { version = "0.3", features = ["subscriber"] }
 fluvio-connectors-common = { path = "../../common", features = ["source"]}
 fluvio-model-postgres = { path = "../../models/fluvio-model-postgres" }

--- a/rust-connectors/sources/syslog/Cargo.toml
+++ b/rust-connectors/sources/syslog/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 syslog_loose = "0.16.0"
 structopt = "0.3"
-fluvio = "0.12"
+fluvio = "0.13"
 thiserror = "1.0.25"
 tokio = { version = "1.18.0", features = ["macros", "rt", ] }
 notify = "5.0.0-pre.14"


### PR DESCRIPTION
Closes #285.

Also:

- Added `aggregate` support to sink connectors
- Changed sink connectors to use smart-modules by name rather than by fetching wasm file and passing again to the SPU