### PR TITLE
[Merged by Bors] - test: spawn connectors using kubernetes access instead of `fluvio connector create`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "connector-deploy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.17",
+ "fluvio-connectors-common",
+ "k8-client",
+ "k8-types",
+ "serde",
+ "serde_yaml",
+ "tokio",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,8 +1740,18 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e2d1fad8e412d44c516add2349a34f6d71d9279b108c8e012325ab17fcbf982"
 dependencies = [
+ "async-io",
+ "async-net",
+ "async-std",
+ "async-trait",
+ "cfg-if 1.0.0",
  "fluvio-wasm-timer",
+ "futures-lite",
+ "futures-util",
  "log",
+ "openssl",
+ "openssl-sys",
+ "pin-project",
  "thiserror",
  "tracing",
  "ws_stream_wasm",
@@ -2307,6 +2331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostfile"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2733206bcc0550a15b450c64d8aa859f486d7281c4c0c36ef904b361960d658"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,7 +2417,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_qs 0.8.5",
  "serde_urlencoded",
  "url",
 ]
@@ -2598,6 +2628,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "k8-client"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3807003ac1d68b31c1cccc9dd0375f2c582ac2f8bb8f35ff581a3b8ed52d9b4"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "cfg-if 1.0.0",
+ "fluvio-future 0.3.18",
+ "futures-util",
+ "http",
+ "hyper",
+ "k8-config",
+ "k8-diff",
+ "k8-metadata-client",
+ "k8-types",
+ "pin-utils",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_qs 0.9.2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "k8-config"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609ad86e094cea1739cd6caf462ee5d55b7d8143afc3a49962e35aaac560e7de"
+dependencies = [
+ "dirs",
+ "hostfile",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "k8-diff"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef435d912eeb448129d7ae11d3c497691f1f383d2d2ff1dff4365a81c7bd4f3b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "k8-metadata-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b5e61b295e6ba9428a64a6a8aee6b05626e8cbe6d4dbcd00617603a7fc8dfa"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "k8-diff",
+ "k8-types",
+ "pin-utils",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "k8-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7652c08ed3d6416ff52f6fa3214519d4ec293921b3a51a21cbd003f2e74c771e"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4070,6 +4179,17 @@ name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af4cee6cd4b23b45e6709150d1e9af5c748131de7e3316a7c2b3008051ed725"
 dependencies = [
  "percent-encoding",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "rust-connectors/sinks/kafka",
     "rust-connectors/models/fluvio-model-postgres",
     "rust-connectors/utils/mocks/http-json-mock/",
+    "rust-connectors/utils/connector-to-k8-deployment",
     "rust-connectors/utils/test-connector",
     "rust-connectors/utils/fluvio-smartstream-map/",
     "examples/github-stars/github-stars-smartmodule-map/",

--- a/build-scripts/docker/build-connector-image.sh
+++ b/build-scripts/docker/build-connector-image.sh
@@ -40,9 +40,9 @@ function main() {
   # Tag the image with a commit hash if we provide it
   if [[ -z "$DOCKER_TAG" ]];
   then
-    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:dev"
+    IMAGE_TAGS="-t $IMAGE_NAME:latest"
   else
-    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:$DOCKER_TAG-${TARGET} -t $IMAGE_NAME:dev"
+    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:$DOCKER_TAG-${TARGET}"
   fi
   DOCKER_IMAGE_TAR=/tmp/infinyon-fluvio-connector-${CONNECTOR_NAME}-${TARGET}.tar
 

--- a/build-scripts/docker/build-connector-image.sh
+++ b/build-scripts/docker/build-connector-image.sh
@@ -40,9 +40,9 @@ function main() {
   # Tag the image with a commit hash if we provide it
   if [[ -z "$DOCKER_TAG" ]];
   then
-    IMAGE_TAGS="-t $IMAGE_NAME:latest"
+    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:dev"
   else
-    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:$DOCKER_TAG-${TARGET}"
+    IMAGE_TAGS="-t $IMAGE_NAME:latest -t $IMAGE_NAME:$DOCKER_TAG-${TARGET} -t $IMAGE_NAME:dev"
   fi
   DOCKER_IMAGE_TAR=/tmp/infinyon-fluvio-connector-${CONNECTOR_NAME}-${TARGET}.tar
 

--- a/examples/github-stars/Makefile
+++ b/examples/github-stars/Makefile
@@ -10,21 +10,24 @@ smart-module-compile:
 	cargo build -p github-stars-smartmodule-map --target wasm32-unknown-unknown --release
 	cargo build -p slack-display-smartmodule-map --target wasm32-unknown-unknown --release
 
+topic-create:
+	fluvio topic create github-stars || true
+
 smart-module-create: smart-module-compile
 	fluvio sm create $(GH_SM_NAME) --wasm-file $(GH_SM)
 	fluvio sm create $(SLACK_SM_NAME) --wasm-file $(SLACK_SM)
 
-slack-connector: smart-module-create
+slack-connector: smart-module-create topic-create
 	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./slack-connector.yaml
 
-http-connector: smart-module-create
+http-connector: smart-module-create topic-create
 	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./http-connector.yaml
 
 clean:
 	fluvio sm delete $(GH_SM_NAME) || true
 	fluvio sm delete $(SLACK_SM_NAME) || true
-	fluvio connector delete github-stars-output || true
-	fluvio connector delete github-stars-input || true
+	cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete --config  ./slack-connector.yaml || true
+	cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete --config ./http-connector.yaml || true
 	fluvio topic delete github-stars || true
 
 

--- a/examples/github-stars/Makefile
+++ b/examples/github-stars/Makefile
@@ -15,10 +15,10 @@ smart-module-create: smart-module-compile
 	fluvio sm create $(SLACK_SM_NAME) --wasm-file $(SLACK_SM)
 
 slack-connector: smart-module-create
-	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml
+	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./slack-connector.yaml
 
 http-connector: smart-module-create
-	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml
+	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./http-connector.yaml
 
 clean:
 	fluvio sm delete $(GH_SM_NAME) || true

--- a/examples/github-stars/Makefile
+++ b/examples/github-stars/Makefile
@@ -15,10 +15,10 @@ smart-module-create: smart-module-compile
 	fluvio sm create $(SLACK_SM_NAME) --wasm-file $(SLACK_SM)
 
 slack-connector: smart-module-create
-	fluvio connector create -c ./slack-connector.yaml
+	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml
 
 http-connector: smart-module-create
-	fluvio connector create -c ./http-connector.yaml
+	cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml
 
 clean:
 	fluvio sm delete $(GH_SM_NAME) || true

--- a/examples/github-stars/README.md
+++ b/examples/github-stars/README.md
@@ -20,14 +20,14 @@ Alternatively:
 `make smart-module-create` does those four commands.
 
 ### Create the connectors
-* `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml`
-* `cargo run --bin connector-deploy  --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml`
+* `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./slack-connector.yaml`
+* `cargo run --bin connector-deploy  --manifest-path ../../Cargo.toml -- apply  -c ./http-connector.yaml`
 
 ## Simple instructions
 * If you feel like doing no work, `make all` will:
     - compile the `aggregate` smartmodule for the http connector
     - compile the `filter_map` smartmodule for the slack connector
     - Add the smartmodules to fluvio vio `fluvio smartmodule create` with the appropriate names and locations.
-    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml`
-    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml`
+    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./http-connector.yaml`
+    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- apply  -c ./slack-connector.yaml`
 * Similar to this `make clean` should destroy all

--- a/examples/github-stars/README.md
+++ b/examples/github-stars/README.md
@@ -28,6 +28,6 @@ Alternatively:
     - compile the `aggregate` smartmodule for the http connector
     - compile the `filter_map` smartmodule for the slack connector
     - Add the smartmodules to fluvio vio `fluvio smartmodule create` with the appropriate names and locations.
-    - `cargo run --bin connector-deploy -- --apply  -c ./http-connector.yaml`
-    - `cargo run --bin connector-deploy -- --apply  -c ./slack-connector.yaml`
+    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml`
+    - `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml`
 * Similar to this `make clean` should destroy all

--- a/examples/github-stars/README.md
+++ b/examples/github-stars/README.md
@@ -20,14 +20,14 @@ Alternatively:
 `make smart-module-create` does those four commands.
 
 ### Create the connectors
-* `fluvio connector create -c ./slack-connector.yaml`
-* `fluvio connector create -c ./http-connector.yaml`
+* `cargo run --bin connector-deploy --manifest-path ../../Cargo.toml -- --apply  -c ./slack-connector.yaml`
+* `cargo run --bin connector-deploy  --manifest-path ../../Cargo.toml -- --apply  -c ./http-connector.yaml`
 
 ## Simple instructions
 * If you feel like doing no work, `make all` will:
     - compile the `aggregate` smartmodule for the http connector
     - compile the `filter_map` smartmodule for the slack connector
     - Add the smartmodules to fluvio vio `fluvio smartmodule create` with the appropriate names and locations.
-    - `fluvio connector create -c ./http-connector.yaml`
-    - `fluvio connector create -c ./slack-connector.yaml`
+    - `cargo run --bin connector-deploy -- --apply  -c ./http-connector.yaml`
+    - `cargo run --bin connector-deploy -- --apply  -c ./slack-connector.yaml`
 * Similar to this `make clean` should destroy all

--- a/examples/python-client-connector/example-connector.yaml
+++ b/examples/python-client-connector/example-connector.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: cat-facts-connector
 type: cat-facts
 create_topic: true

--- a/rust-connectors/sources/http/examp.yaml
+++ b/rust-connectors/sources/http/examp.yaml
@@ -3,7 +3,6 @@ name: route-data
 type: http-json
 topic: routes-info
 create_topic: true
-direction: source
 parameters:
   endpoint: https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql
   method: POST

--- a/rust-connectors/sources/http/tests/get-smartstream-config.yaml
+++ b/rust-connectors/sources/http/tests/get-smartstream-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -6,6 +6,6 @@ create_topic: true
 parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
-  body: ''
+  body: ""
   interval: 1s
   map: http-json-connector-map

--- a/rust-connectors/sources/http/tests/get-smartstream-test.bats
+++ b/rust-connectors/sources/http/tests/get-smartstream-test.bats
@@ -19,7 +19,7 @@ setup() {
 
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-smartstream-test.bats
+++ b/rust-connectors/sources/http/tests/get-smartstream-test.bats
@@ -19,7 +19,7 @@ setup() {
 
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-smartstream-test.bats
+++ b/rust-connectors/sources/http/tests/get-smartstream-test.bats
@@ -11,6 +11,7 @@ setup() {
     cp ./tests/get-smartstream-config.yaml $FILE
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC || true
 
     MODULE=${UUID}-map
     fluvio smart-module create $MODULE --wasm-file ../../../target/wasm32-unknown-unknown/release/fluvio_wasm_map.wasm
@@ -23,7 +24,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     fluvio smart-module delete $MODULE
     kill $MOCK_PID

--- a/rust-connectors/sources/http/tests/get-smartstream-test.bats
+++ b/rust-connectors/sources/http/tests/get-smartstream-test.bats
@@ -19,7 +19,7 @@ setup() {
 
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -6,5 +6,5 @@ create_topic: true
 parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
-  body: ''
+  body: ""
   interval: "1s"

--- a/rust-connectors/sources/http/tests/get-test-full-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-full-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -7,5 +7,5 @@ parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
   output_parts: full
-  body: ''
+  body: ""
   interval: 1s

--- a/rust-connectors/sources/http/tests/get-test-full-json-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-full-json-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -8,5 +8,5 @@ parameters:
   method: GET
   output_parts: full
   output_type: json
-  body: ''
+  body: ""
   interval: 1s

--- a/rust-connectors/sources/http/tests/get-test-full-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-full-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-full-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-full-json.bats
@@ -11,6 +11,7 @@ setup() {
     cp ./tests/get-test-full-json-config.yaml $FILE
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC || true
 
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
@@ -19,7 +20,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/get-test-full-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-full-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-full-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-full-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-full.bats
+++ b/rust-connectors/sources/http/tests/get-test-full.bats
@@ -11,6 +11,7 @@ setup() {
     cp ./tests/get-test-full-config.yaml $FILE
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC || true
 
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
@@ -19,7 +20,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/get-test-full.bats
+++ b/rust-connectors/sources/http/tests/get-test-full.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-full.bats
+++ b/rust-connectors/sources/http/tests/get-test-full.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-full.bats
+++ b/rust-connectors/sources/http/tests/get-test-full.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-json-config.yaml
+++ b/rust-connectors/sources/http/tests/get-test-json-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -7,5 +7,5 @@ parameters:
   endpoint: http://IP_ADDRESS:8080/get
   method: GET
   output_type: json
-  body: ''
+  body: ""
   interval: 1s

--- a/rust-connectors/sources/http/tests/get-test-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-json.bats
@@ -11,6 +11,7 @@ setup() {
     cp ./tests/get-test-json-config.yaml $FILE
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC || true
 
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
@@ -19,7 +20,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/get-test-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test-json.bats
+++ b/rust-connectors/sources/http/tests/get-test-json.bats
@@ -15,7 +15,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test.bats
+++ b/rust-connectors/sources/http/tests/get-test.bats
@@ -8,6 +8,7 @@ setup() {
     cp ./tests/get-test-config.yaml $FILE
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
+    fluvio topic create $TOPIC || true
 
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
@@ -16,7 +17,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/get-test.bats
+++ b/rust-connectors/sources/http/tests/get-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test.bats
+++ b/rust-connectors/sources/http/tests/get-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-test.bats
+++ b/rust-connectors/sources/http/tests/get-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-time-test-config.yaml
+++ b/rust-connectors/sources/http/tests/get-time-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic
@@ -6,7 +6,7 @@ create_topic: true
 parameters:
   endpoint: http://IP_ADDRESS:8080/time
   method: GET
-  body: ''
+  body: ""
   interval: "100ms"
 producer:
   linger: 0ms

--- a/rust-connectors/sources/http/tests/get-time-test.bats
+++ b/rust-connectors/sources/http/tests/get-time-test.bats
@@ -9,6 +9,8 @@ setup() {
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
 
+    fluvio topic create $TOPIC || true
+
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
@@ -16,7 +18,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/get-time-test.bats
+++ b/rust-connectors/sources/http/tests/get-time-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-time-test.bats
+++ b/rust-connectors/sources/http/tests/get-time-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/get-time-test.bats
+++ b/rust-connectors/sources/http/tests/get-time-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/post-test-config.yaml
+++ b/rust-connectors/sources/http/tests/post-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: http-json-connector
 type: http-source
 topic: http-json-connector-topic

--- a/rust-connectors/sources/http/tests/post-test.bats
+++ b/rust-connectors/sources/http/tests/post-test.bats
@@ -16,7 +16,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete --config $FILE
     fluvio topic delete $TOPIC
     kill $MOCK_PID
 }

--- a/rust-connectors/sources/http/tests/post-test.bats
+++ b/rust-connectors/sources/http/tests/post-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/post-test.bats
+++ b/rust-connectors/sources/http/tests/post-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/http/tests/post-test.bats
+++ b/rust-connectors/sources/http/tests/post-test.bats
@@ -12,7 +12,7 @@ setup() {
     sed -i.BAK "s/http-json-connector/${UUID}/g" $FILE
     IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
     sed -i.BAK "s/IP_ADDRESS/${IP_ADDRESS}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/mqtt/tests/simple.bats
+++ b/rust-connectors/sources/mqtt/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     TOPIC=${UUID}-topic
     sed -i.BAK "s/mqtt-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/mqtt/tests/simple.bats
+++ b/rust-connectors/sources/mqtt/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     TOPIC=${UUID}-topic
     sed -i.BAK "s/mqtt-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/mqtt/tests/simple.bats
+++ b/rust-connectors/sources/mqtt/tests/simple.bats
@@ -6,12 +6,12 @@ setup() {
     UUID=$(uuidgen)
     TOPIC=${UUID}-topic
     sed -i.BAK "s/mqtt-connector-name/${UUID}/g" $FILE
-    fluvio topic create $TOPIC
+    fluvio topic create $TOPIC || true
     cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/sources/mqtt/tests/simple.bats
+++ b/rust-connectors/sources/mqtt/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     TOPIC=${UUID}-topic
     sed -i.BAK "s/mqtt-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/mqtt/tests/test-config.yaml
+++ b/rust-connectors/sources/mqtt/tests/test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: mqtt-connector-name
 type: mqtt-source
 topic: mqtt-connector-name-topic

--- a/rust-connectors/sources/postgres/connect.yml
+++ b/rust-connectors/sources/postgres/connect.yml
@@ -1,5 +1,5 @@
 version: v1
-connector_version: dev
+connector_version: latest
 name: fluvio-postgres
 type: postgres
 topic: postgres

--- a/rust-connectors/sources/postgres/tests/simple.bats
+++ b/rust-connectors/sources/postgres/tests/simple.bats
@@ -26,7 +26,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID && echo "Connector deleted: $UUID" >&2
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE && echo "Connector deleted: $UUID" >&2
     fluvio topic delete $TOPIC
 
     kubectl delete pod postgres-leader

--- a/rust-connectors/sources/postgres/tests/simple.bats
+++ b/rust-connectors/sources/postgres/tests/simple.bats
@@ -22,7 +22,7 @@ setup() {
     echo "Got TOPIC $TOPIC" >&2
     sed -i.BAK "s/postgres-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/postgres/tests/simple.bats
+++ b/rust-connectors/sources/postgres/tests/simple.bats
@@ -22,7 +22,7 @@ setup() {
     echo "Got TOPIC $TOPIC" >&2
     sed -i.BAK "s/postgres-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/postgres/tests/simple.bats
+++ b/rust-connectors/sources/postgres/tests/simple.bats
@@ -22,7 +22,7 @@ setup() {
     echo "Got TOPIC $TOPIC" >&2
     sed -i.BAK "s/postgres-connector-name/${UUID}/g" $FILE
     fluvio topic create $TOPIC
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/sources/postgres/tests/simple.yml
+++ b/rust-connectors/sources/postgres/tests/simple.yml
@@ -1,5 +1,5 @@
 version: v1
-connector_version: dev
+connector_version: latest
 name: postgres-connector-name
 type: postgres-source
 topic: postgres-connector-name-topic

--- a/rust-connectors/utils/connector-to-k8-deployment/Cargo.toml
+++ b/rust-connectors/utils/connector-to-k8-deployment/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "connector-deploy"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"
+clap = { version = "3.1", features = ["std", "derive"], default-features = false }
+fluvio-connectors-common = { path = "../../common" }
+k8-types = { version = "0.6.0", default-features = false, features = ["app"] }
+k8-client = "7.0.0"
+serde = { version = "1.0.127", features = ["derive"] }
+serde_yaml = "0.8.18"
+tokio = { version = "1", features = ["full"] }

--- a/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
+++ b/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+
+use clap::Parser;
+use fluvio_connectors_common::config::{ConnectorConfig, ManagedConnectorParameterValue};
+use k8_client::{meta_client::MetadataClient, K8Config};
+use k8_types::{
+    app::deployment::DeploymentSpec,
+    core::pod::{
+        ConfigMapVolumeSource, ContainerSpec, ImagePullPolicy, KeyToPath, PodSecurityContext,
+        PodSpec, VolumeMount, VolumeSpec,
+    },
+    Env, InputK8Obj, LabelProvider, LabelSelector, TemplateMeta, TemplateSpec,
+};
+
+const DEFAULT_CONNECTOR_NAME: &'static str = "fluvio-connector";
+
+#[tokio::main]
+async fn main() {
+    let config: ConfigOpt = ConfigOpt::from_args();
+    config.execute().await.expect("failed to execute");
+}
+
+#[derive(Debug, Parser)]
+pub struct ConfigOpt {
+    /// path to the connector config
+    #[clap(short = 'c', long)]
+    config: String,
+    /// apply to current kubernetes context
+    apply: bool,
+}
+
+impl ConfigOpt {
+    pub async fn execute(self) -> anyhow::Result<()> {
+        let config = ConnectorConfig::from_file(self.config)?;
+        let deployment = convert_to_k8_deployment(config)?;
+
+        if self.apply {
+            let k8_config = K8Config::load().expect("no k8 config found");
+            let client = k8_client::new_shared(k8_config).expect("failed to create k8 client");
+
+            let input = InputK8Obj::new(deployment, Default::default());
+
+            client.apply(input).await?;
+        } else {
+            println!("{}", serde_yaml::to_string(&deployment)?);
+        }
+
+        Ok(())
+    }
+}
+
+fn convert_to_k8_deployment(config: ConnectorConfig) -> anyhow::Result<DeploymentSpec> {
+    // Volume:
+    // - configMap:
+    //     defaultMode: 420
+    //     items:
+    //     - key: fluvioClientConfig
+    //       path: config
+    //     name: fluvio-config-map
+    //   name: fluvio-config-volume
+    let config_map_volume_spec = VolumeSpec {
+        name: "fluvio-config-volume".to_string(),
+        config_map: Some(ConfigMapVolumeSource {
+            name: Some("fluvio-config-map".to_string()),
+            items: Some(vec![KeyToPath {
+                key: "fluvioClientConfig".to_string(),
+                path: "config".to_string(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let parameters = &config.parameters;
+
+    let parameters: Vec<String> = parameters
+        .keys()
+        .zip(parameters.values())
+        .flat_map(|(key, values)| match &values {
+            ManagedConnectorParameterValue::String(value) => {
+                vec![format!("--{}={}", key.replace('_', "-"), value)]
+            }
+            ManagedConnectorParameterValue::Vec(values) => {
+                let mut args = Vec::new();
+                for value in values.iter() {
+                    args.push(format!("--{}={}", key.replace('_', "-"), value))
+                }
+                args
+            }
+            ManagedConnectorParameterValue::Map(map) => {
+                let mut args = Vec::new();
+                for (sub_key, value) in map.iter() {
+                    args.push(format!(
+                        "--{}={}:{}",
+                        key.replace('_', "-"),
+                        sub_key.replace('_', "-"),
+                        value
+                    ));
+                }
+                args
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Prefixing the args with a "--" passed to the container is needed for an unclear reason.
+    let mut args = vec!["--".to_string(), format!("--fluvio-topic={}", config.topic)];
+    args.extend(parameters);
+
+    let type_ = &config.type_;
+    let image = format!("infinyon/fluvio-connect-{}:{}", type_, config.version);
+
+    let volume_mounts = vec![VolumeMount {
+        name: "fluvio-config-volume".to_string(),
+        mount_path: "/home/fluvio/.fluvio".to_string(),
+        ..Default::default()
+    }];
+
+    let volumes = vec![config_map_volume_spec];
+
+    let secrets = &config.secrets;
+    let env: Vec<Env> = secrets
+        .keys()
+        .zip(secrets.values())
+        .flat_map(|(key, value)| [Env::key_value(key, &(**value).to_string())])
+        .collect::<Vec<_>>();
+
+    let template = TemplateSpec {
+        metadata: Some(TemplateMeta::default().set_labels(vec![
+            ("app", DEFAULT_CONNECTOR_NAME),
+            ("connectorName", &config.name),
+        ])),
+        spec: PodSpec {
+            termination_grace_period_seconds: Some(10),
+            security_context: Some(PodSecurityContext {
+                fs_group: Some(1000),
+                ..Default::default()
+            }),
+            containers: vec![ContainerSpec {
+                name: DEFAULT_CONNECTOR_NAME.to_owned(),
+                image: Some(image),
+                image_pull_policy: Some(ImagePullPolicy::IfNotPresent),
+                env,
+                volume_mounts,
+                args,
+                ..Default::default()
+            }],
+            volumes,
+            ..Default::default()
+        },
+    };
+
+    let mut match_labels = HashMap::new();
+    match_labels.insert("app".to_owned(), DEFAULT_CONNECTOR_NAME.to_owned());
+    match_labels.insert("connectorName".to_owned(), config.name.clone());
+
+    Ok(DeploymentSpec {
+        template,
+        selector: LabelSelector { match_labels },
+        ..Default::default()
+    })
+}

--- a/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
+++ b/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
@@ -200,7 +200,7 @@ fn convert_to_k8_deployment(config: &ConnectorConfig) -> anyhow::Result<Deployme
             containers: vec![ContainerSpec {
                 name: DEFAULT_CONNECTOR_NAME.to_owned(),
                 image: Some(image),
-                image_pull_policy: Some(ImagePullPolicy::IfNotPresent),
+                image_pull_policy: Some(ImagePullPolicy::Never),
                 env,
                 volume_mounts,
                 args,

--- a/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
+++ b/rust-connectors/utils/connector-to-k8-deployment/src/main.rs
@@ -12,7 +12,7 @@ use k8_types::{
     Env, InputK8Obj, LabelProvider, LabelSelector, TemplateMeta, TemplateSpec,
 };
 
-const DEFAULT_CONNECTOR_NAME: &'static str = "fluvio-connector";
+const DEFAULT_CONNECTOR_NAME: &str = "fluvio-connector";
 
 #[tokio::main]
 async fn main() {

--- a/rust-connectors/utils/test-connector/tests/batch-size-test-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/batch-size-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: test-connector-name
 type: test-connector
 topic: test-connector-name-topic

--- a/rust-connectors/utils/test-connector/tests/batch-size-test.bats
+++ b/rust-connectors/utils/test-connector/tests/batch-size-test.bats
@@ -7,11 +7,12 @@ setup() {
     cp ./tests/batch-size-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
+    fluvio topic create $TOPIC || true
     cargo run --bin connector-deploy  --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/utils/test-connector/tests/batch-size-test.bats
+++ b/rust-connectors/utils/test-connector/tests/batch-size-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/batch-size-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy  --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/batch-size-test.bats
+++ b/rust-connectors/utils/test-connector/tests/batch-size-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/batch-size-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/batch-size-test.bats
+++ b/rust-connectors/utils/test-connector/tests/batch-size-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/batch-size-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy  --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy  --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/connector-deployment.yaml
+++ b/rust-connectors/utils/test-connector/tests/connector-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-connector-name
+spec:
+  selector:
+    matchLabels:
+      app: fluvio-connector
+      connectorName: test-connector-name
+  template:
+    metadata:
+      labels:
+        app: fluvio-connector
+        connectorName: test-connector-name
+    spec:
+      containers:
+      - args:
+        - --
+        - --fluvio-topic=test-connector-name-topic
+        - --producer-linger=1ms
+        - --timeout=1ms
+        image: infinyon/fluvio-connect-test-connector
+        imagePullPolicy: Never
+        name: fluvio-connector
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /home/fluvio/.fluvio
+          name: fluvio-config-volume
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: fluvioClientConfig
+            path: config
+          name: fluvio-config-map
+        name: fluvio-config-volume

--- a/rust-connectors/utils/test-connector/tests/fluvio-test.bats
+++ b/rust-connectors/utils/test-connector/tests/fluvio-test.bats
@@ -12,7 +12,7 @@ setup() {
     cp ./tests/test-mode-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/fluvio-test.bats
+++ b/rust-connectors/utils/test-connector/tests/fluvio-test.bats
@@ -16,7 +16,7 @@ setup() {
 }
 
 teardown() {
-    fluvio connector delete $UUID-fluvio-test
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/utils/test-connector/tests/fluvio-test.bats
+++ b/rust-connectors/utils/test-connector/tests/fluvio-test.bats
@@ -12,7 +12,7 @@ setup() {
     cp ./tests/test-mode-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/fluvio-test.bats
+++ b/rust-connectors/utils/test-connector/tests/fluvio-test.bats
@@ -12,7 +12,7 @@ setup() {
     cp ./tests/test-mode-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/gzip-test-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/gzip-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: test-connector-name
 type: test-connector
 topic: test-connector-name-topic

--- a/rust-connectors/utils/test-connector/tests/gzip-test.bats
+++ b/rust-connectors/utils/test-connector/tests/gzip-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/gzip-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/gzip-test.bats
+++ b/rust-connectors/utils/test-connector/tests/gzip-test.bats
@@ -7,11 +7,12 @@ setup() {
     cp ./tests/gzip-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
+    fluvio topic create $TOPIC || true
     cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/utils/test-connector/tests/gzip-test.bats
+++ b/rust-connectors/utils/test-connector/tests/gzip-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/gzip-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/gzip-test.bats
+++ b/rust-connectors/utils/test-connector/tests/gzip-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/gzip-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/linger-test-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/linger-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: test-connector-name
 type: test-connector
 topic: test-connector-name-topic

--- a/rust-connectors/utils/test-connector/tests/linger-test.bats
+++ b/rust-connectors/utils/test-connector/tests/linger-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/linger-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/linger-test.bats
+++ b/rust-connectors/utils/test-connector/tests/linger-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/linger-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/linger-test.bats
+++ b/rust-connectors/utils/test-connector/tests/linger-test.bats
@@ -7,11 +7,12 @@ setup() {
     cp ./tests/linger-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
+    fluvio topic create $TOPIC || true
     cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/utils/test-connector/tests/linger-test.bats
+++ b/rust-connectors/utils/test-connector/tests/linger-test.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/linger-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/simple-test-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/simple-test-config.yaml
@@ -3,7 +3,6 @@ name: test-connector-name
 type: test-connector
 topic: test-connector-name-topic
 create_topic: true
-direction: source
 parameters:
   timeout: "1ms"
 producer:

--- a/rust-connectors/utils/test-connector/tests/simple-test-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/simple-test-config.yaml
@@ -1,4 +1,4 @@
-version: dev
+version: latest
 name: test-connector-name
 type: test-connector
 topic: test-connector-name-topic

--- a/rust-connectors/utils/test-connector/tests/simple.bats
+++ b/rust-connectors/utils/test-connector/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/simple-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/simple.bats
+++ b/rust-connectors/utils/test-connector/tests/simple.bats
@@ -7,11 +7,12 @@ setup() {
     cp ./tests/simple-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
+    fluvio topic create $TOPIC || true
     cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {
-    fluvio connector delete $UUID
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- delete  --config $FILE
     fluvio topic delete $TOPIC
 }
 

--- a/rust-connectors/utils/test-connector/tests/simple.bats
+++ b/rust-connectors/utils/test-connector/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/simple-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    fluvio connector create --config $FILE
+    cargo run --bin connector-deploy -- --apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/simple.bats
+++ b/rust-connectors/utils/test-connector/tests/simple.bats
@@ -7,7 +7,7 @@ setup() {
     cp ./tests/simple-test-config.yaml $FILE
 
     sed -i.BAK "s/test-connector-name/${UUID}/g" $FILE
-    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- --apply  --config $FILE
+    cargo run --bin connector-deploy --manifest-path ../../../Cargo.toml -- apply  --config $FILE
 }
 
 teardown() {

--- a/rust-connectors/utils/test-connector/tests/test-mode-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/test-mode-config.yaml
@@ -4,7 +4,6 @@ name: test-connector-name-fluvio-test
 type: test-connector
 topic: longevity
 create_topic: true
-direction: source
 parameters:
   test-name: longevity
   runner-opts: --timeout 30s --producer 1 --consumer 1

--- a/rust-connectors/utils/test-connector/tests/test-mode-config.yaml
+++ b/rust-connectors/utils/test-connector/tests/test-mode-config.yaml
@@ -1,5 +1,5 @@
-version: dev
-#connector_version: dev
+version: latest
+#connector_version: latest
 name: test-connector-name-fluvio-test
 type: test-connector
 topic: longevity


### PR DESCRIPTION
Fixes https://github.com/infinyon/fluvio-connectors/issues/311

This PR adds `connector-deploy` binary that can be used to create a kubernetes deployment in the current namespace and cluster. This is done in order to remove the usage of `fluvio connector create` and `delete` for CI tests

Example:
```
cargo run --bin connector-deploy  -- apply --config /path/to/connector-config.yaml
```

Also we can use the delete subcommand and the print subcomand  to delete and print the k8 deploment.