### PR TITLE
feat(cli): added support for `transform` section in connector config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "arrayref"
@@ -140,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -207,10 +216,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+checksum = "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
 dependencies = [
+ "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
@@ -244,22 +254,24 @@ dependencies = [
 
 [[package]]
 name = "async-net"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5373304df79b9b4395068fb080369ec7178608827306ce4d081cba51cac551df"
+checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
 dependencies = [
  "async-io",
+ "autocfg",
  "blocking",
  "futures-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
 dependencies = [
  "async-io",
+ "autocfg",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
@@ -345,15 +357,15 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -561,7 +573,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time 0.3.11",
+ "time 0.3.14",
  "tracing",
 ]
 
@@ -665,7 +677,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.11",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -694,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -798,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -842,7 +854,7 @@ version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c408da54db4c50d4693f7e649c299bc9de9c23ead86249e5368830bb32a734b"
 dependencies = [
- "semver 1.0.12",
+ "semver 1.0.13",
  "serde",
  "toml",
  "url",
@@ -871,12 +883,12 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
+ "iana-time-zone",
  "js-sys",
- "libc",
  "num-integer",
  "num-traits",
  "serde",
@@ -911,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -925,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -967,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
 ]
@@ -979,11 +991,13 @@ name = "connector-run"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
+ "itertools",
  "k8-client",
  "k8-types",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tokio",
 ]
@@ -1053,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -1068,18 +1082,18 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529ffacce2249ac60edba2941672dfedf3d96558b415d0d8083cd007456e0f55"
+checksum = "93945adbccc8d731503d3038814a51e8317497c9e205411820348132fa01a358"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427d105f617efc8cb55f8d036a7fded2e227892d8780b4985e5551f8d27c4a92"
+checksum = "2b482acc9d0d0d1ad3288a90a8150ee648be3dce8dc8c8669ff026f72debdc31"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -1095,33 +1109,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551674bed85b838d45358e3eab4f0ffaa6790c70dc08184204b9a54b41cdb7d1"
+checksum = "f9ec188d71e663192ef9048f204e410a7283b609942efc9fcc77da6d496edbb8"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3a63ae57498c3eb495360944a33571754241e15e47e3bcae6082f40fec5866"
+checksum = "3ad794b1b1c2c7bd9f7b76cfe0f084eaf7753e55d56191c3f7d89e8fa4978b99"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11aa8aa624c72cc1c94ea3d0739fa61248260b5b14d3646f51593a88d67f3e6e"
+checksum = "342da0d5056f4119d3c311c4aab2460ceb6ee6e127bb395b76dd2279a09ea7a5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544ee8f4d1c9559c9aa6d46e7aaeac4a13856d620561094f35527356c7d21bd0"
+checksum = "dfff792f775b07d4d9cfe9f1c767ce755c6cbadda1bbd6db18a1c75ff9f7376a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1131,15 +1145,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed16b14363d929b8c37e3c557d0a7396791b383ecc302141643c054343170aad"
+checksum = "8d51089478849f2ac8ef60a8a2d5346c8d4abfec0e45ac5b24530ef9f9499e1e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51617cf8744634f2ed3c989c3c40cd6444f63377c6d994adab0d85807f3eb682"
+checksum = "885debe62f2078638d6585f54c9f05f5c2008f22ce5a2a9100ada785fc065dbd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1148,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.86.1"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8073a41efc173fd19bad3f725c170c705df6da999fc47a738ff310225dd63"
+checksum = "4f0cf00e1f3f2eca29a779fc23b117a408b5d59ce85af2859322b9014ae0af63"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1197,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1207,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -1218,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
@@ -1232,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
@@ -1242,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1281,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
@@ -1445,9 +1459,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "dynamodb-sink"
@@ -1456,7 +1470,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-dynamodb",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "schemars",
@@ -1466,10 +1480,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.7.0"
+name = "educe"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -1478,6 +1504,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
 ]
 
 [[package]]
@@ -1495,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d013529d5574a60caeda29e179e695125448e5de52e3874f7b4c1d7360e18e"
+checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
 dependencies = [
  "serde",
 ]
@@ -1525,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -1547,9 +1587,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -1632,19 +1672,57 @@ dependencies = [
  "derive_builder",
  "dirs",
  "event-listener",
- "fluvio-compression",
+ "fluvio-compression 0.2.0",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.2",
- "fluvio-protocol",
- "fluvio-sc-schema",
- "fluvio-smartengine",
- "fluvio-socket",
- "fluvio-spu-schema",
- "fluvio-types",
+ "fluvio-protocol 0.7.9",
+ "fluvio-sc-schema 0.14.0",
+ "fluvio-socket 0.12.1",
+ "fluvio-spu-schema 0.10.0",
+ "fluvio-types 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "once_cell",
  "pin-project-lite 0.2.9",
- "semver 1.0.12",
+ "semver 1.0.13",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio"
+version = "0.14.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-rwlock",
+ "async-trait",
+ "base64 0.13.0",
+ "built",
+ "bytes",
+ "cfg-if 1.0.0",
+ "chrono",
+ "derive_builder",
+ "dirs",
+ "event-listener",
+ "fluvio-compression 0.2.1",
+ "fluvio-future 0.4.2",
+ "fluvio-protocol 0.8.0",
+ "fluvio-sc-schema 0.15.0",
+ "fluvio-smartengine",
+ "fluvio-smartmodule 0.4.0",
+ "fluvio-socket 0.13.0",
+ "fluvio-spu-schema 0.10.1",
+ "fluvio-types 0.3.8 (git+https://github.com/infinyon/fluvio)",
+ "futures-util",
+ "once_cell",
+ "pin-project-lite 0.2.9",
+ "semver 1.0.13",
  "serde",
  "serde_json",
  "siphasher",
@@ -1669,16 +1747,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-compression"
+version = "0.2.1"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "bytes",
+ "flate2",
+ "lz4_flex",
+ "serde",
+ "snap",
+ "thiserror",
+]
+
+[[package]]
 name = "fluvio-connectors-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytesize",
- "clap 3.2.17",
+ "clap 3.2.19",
  "flate2",
- "fluvio",
+ "fluvio 0.14.0",
  "fluvio-future 0.4.2",
- "fluvio-spu-schema",
+ "fluvio-protocol 0.8.0",
+ "fluvio-smartengine",
+ "fluvio-spu-schema 0.10.0",
  "humantime",
  "humantime-serde",
  "pretty_assertions",
@@ -1701,9 +1794,26 @@ dependencies = [
  "base64 0.13.0",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.3.18",
- "fluvio-protocol",
- "fluvio-stream-model",
- "fluvio-types",
+ "fluvio-protocol 0.7.9",
+ "fluvio-stream-model 0.6.1",
+ "fluvio-types 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flv-util",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-controlplane-metadata"
+version = "0.19.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "fluvio-future 0.4.2",
+ "fluvio-protocol 0.8.0",
+ "fluvio-stream-model 0.8.1",
+ "fluvio-types 0.3.8 (git+https://github.com/infinyon/fluvio)",
  "flv-util",
  "thiserror",
  "tracing",
@@ -1721,14 +1831,14 @@ dependencies = [
  "content_inspector",
  "crc32c",
  "eyre",
- "fluvio-compression",
+ "fluvio-compression 0.2.0",
  "fluvio-future 0.4.2",
- "fluvio-protocol",
- "fluvio-types",
+ "fluvio-protocol 0.7.9",
+ "fluvio-types 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "flv-util",
  "futures-util",
  "once_cell",
- "semver 1.0.12",
+ "semver 1.0.13",
  "thiserror",
  "tracing",
 ]
@@ -1772,7 +1882,6 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "log",
- "nix",
  "openssl",
  "openssl-sys",
  "pin-project",
@@ -1797,7 +1906,28 @@ checksum = "6a5fa561c1628d40bdde2fbde33cb1ce4597386a3f943b45b09703bc3534cf2d"
 dependencies = [
  "bytes",
  "fluvio-future 0.4.2",
- "fluvio-protocol-derive",
+ "fluvio-protocol-derive 0.4.2",
+ "tokio-util 0.7.3",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.8.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "bytes",
+ "content_inspector",
+ "crc32c",
+ "eyre",
+ "fluvio-compression 0.2.1",
+ "fluvio-future 0.4.2",
+ "fluvio-protocol-derive 0.4.3",
+ "fluvio-types 0.3.8 (git+https://github.com/infinyon/fluvio)",
+ "flv-util",
+ "once_cell",
+ "semver 1.0.13",
+ "thiserror",
  "tokio-util 0.7.3",
  "tracing",
 ]
@@ -1815,15 +1945,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-protocol-derive"
+version = "0.4.3"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "tracing",
+]
+
+[[package]]
 name = "fluvio-sc-schema"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdc8c0790b81d350c5bd787b9357da7d4021ab23b106526e31b76e9245af974b"
 dependencies = [
- "fluvio-controlplane-metadata",
+ "fluvio-controlplane-metadata 0.15.4",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
- "fluvio-types",
+ "fluvio-protocol 0.7.9",
+ "fluvio-types 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "paste",
+ "static_assertions",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-sc-schema"
+version = "0.15.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "fluvio-controlplane-metadata 0.19.0",
+ "fluvio-protocol 0.8.0",
+ "fluvio-types 0.3.8 (git+https://github.com/infinyon/fluvio)",
  "log",
  "paste",
  "static_assertions",
@@ -1833,15 +1989,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio-smartengine"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff08aeed1dfae0c946f2748ef685cdbed502034fd20ba03f71b444203869bde"
+version = "0.4.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
 dependencies = [
  "anyhow",
- "fluvio-dataplane-protocol",
+ "flate2",
  "fluvio-future 0.4.2",
- "fluvio-spu-schema",
- "futures-util",
+ "fluvio-protocol 0.8.0",
+ "fluvio-smartmodule 0.4.0",
  "nix",
  "thiserror",
  "tracing",
@@ -1856,7 +2011,19 @@ checksum = "1ef31561078a389034e04bbeae58cd4cac64282bd7e75c8195422fba4fe68b53"
 dependencies = [
  "eyre",
  "fluvio-dataplane-protocol",
- "fluvio-smartmodule-derive",
+ "fluvio-smartmodule-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fluvio-smartmodule"
+version = "0.4.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "eyre",
+ "fluvio-protocol 0.8.0",
+ "fluvio-smartmodule-derive 0.2.1 (git+https://github.com/infinyon/fluvio)",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1864,6 +2031,16 @@ name = "fluvio-smartmodule-derive"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16a97199cab326dcc210e8c771c8b99bfbd32ddb0e5ce1bfe54e303b8c3d3955"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fluvio-smartmodule-derive"
+version = "0.2.1"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1883,7 +2060,29 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener",
  "fluvio-future 0.4.2",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.9",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.3",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-socket"
+version = "0.13.0"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-trait",
+ "bytes",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "fluvio-future 0.4.2",
+ "fluvio-protocol 0.8.0",
  "futures-util",
  "once_cell",
  "pin-project",
@@ -1902,7 +2101,24 @@ dependencies = [
  "bytes",
  "flate2",
  "fluvio-dataplane-protocol",
- "fluvio-protocol",
+ "fluvio-protocol 0.7.9",
+ "log",
+ "serde",
+ "static_assertions",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-spu-schema"
+version = "0.10.1"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "bytes",
+ "educe",
+ "fluvio-future 0.4.2",
+ "fluvio-protocol 0.8.0",
+ "fluvio-smartengine",
+ "fluvio-smartmodule 0.4.0",
  "log",
  "serde",
  "static_assertions",
@@ -1922,11 +2138,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-stream-model"
+version = "0.8.1"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
+dependencies = [
+ "async-rwlock",
+ "event-listener",
+ "once_cell",
+ "tracing",
+]
+
+[[package]]
 name = "fluvio-syslog"
 version = "0.2.0"
 dependencies = [
  "cfg-if 1.0.0",
- "fluvio",
+ "fluvio 0.13.1",
  "futures-util",
  "notify",
  "serde",
@@ -1950,9 +2177,19 @@ dependencies = [
 
 [[package]]
 name = "fluvio-types"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417d908546297c524804167a0a8714db6512117d1b0fa52cf434e7bfc1577df"
+checksum = "9a675cf4a60aa0bff6f5d9d2c3c5201fc5a214cbb9e9d7f0127c7792314714bf"
+dependencies = [
+ "event-listener",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-types"
+version = "0.3.8"
+source = "git+https://github.com/infinyon/fluvio#e80f3ff7c1626899a7937f1abf55f0bcae76e316"
 dependencies = [
  "event-listener",
  "thiserror",
@@ -1963,7 +2200,7 @@ dependencies = [
 name = "fluvio-wasm-map"
 version = "0.1.0"
 dependencies = [
- "fluvio-smartmodule",
+ "fluvio-smartmodule 0.2.5",
 ]
 
 [[package]]
@@ -2033,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2048,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2058,15 +2295,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2075,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -2096,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2107,15 +2344,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -2125,9 +2362,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2152,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -2196,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -2209,7 +2446,7 @@ dependencies = [
 name = "github-stars-smartmodule-map"
 version = "0.1.0"
 dependencies = [
- "fluvio-smartmodule",
+ "fluvio-smartmodule 0.2.5",
  "serde",
  "serde_json",
 ]
@@ -2228,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -2247,18 +2484,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
@@ -2382,7 +2613,7 @@ dependencies = [
 name = "http-source"
 version = "0.3.1"
 dependencies = [
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-dataplane-protocol",
  "fluvio-future 0.4.2",
@@ -2423,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -2451,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2504,6 +2735,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,7 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown",
  "serde",
 ]
 
@@ -2598,15 +2843,26 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
-name = "ittapi-rs"
-version = "0.2.0"
+name = "ittapi"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f712648a1ad72fbfb7adc2772c331e8d90f022f8cf30cbabefba2878dd3172b0"
+checksum = "663fe0550070071ff59e981864a9cd3ee1c869ed0a088140d9ac4dc05ea6b1a1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e21911b7183f38c71d75ab478a527f314e28db51027037ece2e5511ed9410703"
 dependencies = [
  "cc",
 ]
@@ -2622,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2732,7 +2988,7 @@ name = "kafka-sink"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "kafka",
@@ -2749,7 +3005,7 @@ name = "kafka-source"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "kafka",
@@ -2803,9 +3059,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libz-sys"
@@ -2833,9 +3089,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2854,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74141c8af4bb8136dafb5705826bdd9dce823021db897c1129191804140ddf84"
+checksum = "c038063f7a78126c539d666a0323a2032de5e7366012cd14a6eafc5ba290bbd6"
 dependencies = [
  "twox-hash",
 ]
@@ -2887,9 +3143,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "274fd6bd98a3c75c9515d9393b063099f60f9b47f09ee20a34fd76287fd017f4"
 dependencies = [
  "digest 0.10.3",
 ]
@@ -2952,18 +3208,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "more-asserts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
 name = "mqtt-source"
 version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-global-executor",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "rumqttc",
@@ -3007,14 +3257,16 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
+ "autocfg",
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -3029,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0-pre.15"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
+checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
 dependencies = [
  "bitflags",
  "crossbeam-channel",
@@ -3043,6 +3295,17 @@ dependencies = [
  "mio",
  "walkdir",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3106,21 +3369,21 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.28.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
- "hashbrown 0.11.2",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
@@ -3130,9 +3393,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3171,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -3254,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "percent-encoding"
@@ -3294,18 +3557,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3338,10 +3601,11 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "libc",
  "log",
@@ -3379,7 +3643,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.8.5",
- "sha2 0.10.2",
+ "sha2 0.10.3",
  "stringprep",
 ]
 
@@ -3397,7 +3661,7 @@ dependencies = [
  "md-5",
  "memchr",
  "rand 0.8.5",
- "sha2 0.10.2",
+ "sha2 0.10.3",
  "stringprep",
 ]
 
@@ -3406,18 +3670,18 @@ name = "postgres-sink"
 version = "0.2.1"
 dependencies = [
  "bytes",
- "clap 3.2.17",
+ "clap 3.2.19",
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio",
+ "fluvio 0.13.1",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "fluvio-model-postgres",
  "once_cell",
  "postgres-protocol 0.6.1",
  "postgres-source",
- "postgres-types 0.2.3",
+ "postgres-types 0.2.4",
  "schemars",
  "serde",
  "serde_json",
@@ -3436,11 +3700,11 @@ version = "0.2.1"
 dependencies = [
  "adaptive_backoff",
  "bytes",
- "clap 3.2.17",
+ "clap 3.2.19",
  "color-backtrace",
  "dotenv",
  "eyre",
- "fluvio",
+ "fluvio 0.13.1",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "fluvio-model-postgres",
@@ -3470,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd6e8b7189a73169290e89bd24c771071f1012d8fe6f738f5226531f0b03d89"
+checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3499,10 +3763,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
@@ -3539,27 +3804,27 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd89aa18fbf9533a581355a22438101fe9c2ed8c9e2f0dcf520552a3afddf2"
+checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -3691,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -3752,18 +4017,6 @@ name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "region"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
-dependencies = [
- "bitflags",
- "libc",
- "mach",
- "winapi",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -3909,7 +4162,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.12",
+ "semver 1.0.13",
 ]
 
 [[package]]
@@ -3970,7 +4223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile 1.0.1",
  "schannel",
  "security-framework",
 ]
@@ -3986,18 +4239,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -4071,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -4103,9 +4356,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 dependencies = [
  "serde",
 ]
@@ -4124,18 +4377,18 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4164,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -4209,9 +4462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -4262,9 +4515,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4316,15 +4569,18 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slack-display-smartmodule-map"
 version = "0.1.0"
 dependencies = [
- "fluvio-smartmodule",
+ "fluvio-smartmodule 0.2.5",
  "serde",
  "serde_json",
 ]
@@ -4334,7 +4590,7 @@ name = "slack-sink"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",
  "reqwest",
@@ -4365,9 +4621,9 @@ checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
 dependencies = [
  "libc",
  "winapi",
@@ -4521,9 +4777,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,7 +4831,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-std",
- "clap 3.2.17",
+ "clap 3.2.19",
  "fluvio-connectors-common",
  "fluvio-dataplane-protocol",
  "humantime",
@@ -4601,18 +4857,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4679,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "libc",
  "num_threads",
@@ -4727,9 +4983,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4890,9 +5146,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -4914,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4935,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
  "matchers",
@@ -5003,9 +5259,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -5164,9 +5420,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -5176,13 +5432,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -5191,9 +5447,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5203,9 +5459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5213,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5226,41 +5482,39 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f76068e87fe9b837a6bc2ccded66784173eadb828c4168643e9fddf6f9ed2e61"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.86.0"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcbfe95447da2aa7ff171857fc8427513eb57c75a729bb190e974dc695e8f5c"
+checksum = "fb8cf7dd82407fe68161bedcd57fde15596f32ebf6e9b3bdbf3ae1da20e38e5e"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d10a6853d64e99fffdae80f93a45080475c9267f87743060814dc1186d74618"
+checksum = "7afe5b8ac42a33b4f19a53f677d7475cddceedf1eb78745b3b1f71b72fbe3d09"
 dependencies = [
  "anyhow",
  "async-trait",
- "backtrace",
  "bincode",
  "cfg-if 1.0.0",
  "indexmap",
- "lazy_static",
  "libc",
  "log",
  "object",
@@ -5268,7 +5522,6 @@ dependencies = [
  "paste",
  "psm",
  "rayon",
- "region",
  "serde",
  "target-lexicon",
  "wasmparser",
@@ -5283,10 +5536,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-cache"
-version = "0.39.1"
+name = "wasmtime-asm-macros"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0617b2f4c897b6a89b9d143466f3c724b9a36c6eabc443bf463f4e1ad48a2ccd"
+checksum = "536870d7ba2008b689c1f10e98becd86f17157df3aad2f63e5f308ca13ee2f1f"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce067f86f8eb0a0dbd245e173a6194e034a2aeed739aac64e7a56f303afe7322"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -5304,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302b33d919e8e33f1717d592c10c3cddccb318d0e1e0bef75178f579686ba94"
+checksum = "dc7318d12f5b1ccb71dee548f20d7df649262211fb311ceb419c129c179307f7"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5316,7 +5578,6 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "more-asserts",
  "object",
  "target-lexicon",
  "thiserror",
@@ -5326,16 +5587,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c50fb925e8eaa9f8431f9b784ea89a13c703cb445ddfe51cb437596fc34e734"
+checksum = "f81b3bcb90a2f95a9f4beac7c9bd6f1c11d8f47b6c9731e754b412ae2f7a028d"
 dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
- "more-asserts",
  "object",
  "serde",
  "target-lexicon",
@@ -5346,21 +5606,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6aba0b317746e8213d1f36a4c51974e66e69c1f05bfc09ed29b4d4bda290eb"
+checksum = "4fb9b4c159d0bffa7e427cac4b75798096aedf48f69e137643a201ff5508db3e"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "rustix",
+ "wasmtime-asm-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad81635f33ab69aa04b386c9d954aef9f6230059f66caf67e55fb65bfd2f3e0"
+checksum = "36002a22014a44c0f778022f02ed3c9eb1c47746e318deabe3e442c56608ad99"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5368,10 +5629,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli",
- "ittapi-rs",
+ "ittapi",
  "log",
  "object",
- "region",
  "rustc-demangle",
  "rustix",
  "serde",
@@ -5385,23 +5645,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e23273fddce8cab149a0743c46932bf4910268641397ed86b46854b089f38f"
+checksum = "f53472291468f9150c955f68dbffb82fd38b55bd139a05733d268be1da723a25"
 dependencies = [
- "lazy_static",
  "object",
+ "once_cell",
  "rustix",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b8aafb292502d28dc2d25f44d4a81e229bb2e0cc14ca847dde4448a1a62ae4"
+checksum = "525c5b664b52c02761404ddb4509c865488e0d64436d3723b542ce8f158f562f"
 dependencies = [
  "anyhow",
- "backtrace",
  "cc",
  "cfg-if 1.0.0",
  "indexmap",
@@ -5410,11 +5669,11 @@ dependencies = [
  "mach",
  "memfd",
  "memoffset",
- "more-asserts",
+ "paste",
  "rand 0.8.5",
- "region",
  "rustix",
  "thiserror",
+ "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
@@ -5423,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7edc34f358fc290d12e326de81884422cb94cf74cc305b27979569875332d6"
+checksum = "b1838152db55efc5d030ed4f91e947216b7466621169da28a3fca6d2c4b6053b"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -5435,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "43.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "408feaebf6dbf9d154957873b14d00e8fba4cbc17a8cbb1bc9e4c1db425c50a8"
+checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
 dependencies = [
  "leb128",
  "memchr",
@@ -5447,18 +5706,18 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.45"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b70bfff0cfaf33dc9d641196dbcd0023a2da8b4b9030c59535cb44e2884983b"
+checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5637,9 +5896,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,18 +1082,18 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93945adbccc8d731503d3038814a51e8317497c9e205411820348132fa01a358"
+checksum = "9f91425bea5a5ac6d76b788477064944a7e21f0e240fd93f6f368a774a3efdd1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b482acc9d0d0d1ad3288a90a8150ee648be3dce8dc8c8669ff026f72debdc31"
+checksum = "8b83b4bbf7bc96db77b7b5b5e41fafc4001536e9f0cbfd702ed7d4d8f848dc06"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -1109,33 +1109,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec188d71e663192ef9048f204e410a7283b609942efc9fcc77da6d496edbb8"
+checksum = "da02e8fff048c381b313a3dfef4deb2343976fb6d7acc8e7d9c86d4c93e3fa06"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad794b1b1c2c7bd9f7b76cfe0f084eaf7753e55d56191c3f7d89e8fa4978b99"
+checksum = "9abc2a06e8fc29e36660ebbc9e2503e18a051057072acbb1e75e7f7cf19cb95e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342da0d5056f4119d3c311c4aab2460ceb6ee6e127bb395b76dd2279a09ea7a5"
+checksum = "aeced7874890fc25d85cacc5e626c4d67931c7c25aad1c2ad521684744c1ff5c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfff792f775b07d4d9cfe9f1c767ce755c6cbadda1bbd6db18a1c75ff9f7376a"
+checksum = "fc1d301ccad6fce05d9c9793d433d225fafdd57661b98d268d8d162e9291ff2e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1145,15 +1145,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d51089478849f2ac8ef60a8a2d5346c8d4abfec0e45ac5b24530ef9f9499e1e"
+checksum = "bd7b100db19320848986b4df1da19501dbddeb706a799f502222f72f889b0fab"
 
 [[package]]
 name = "cranelift-native"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885debe62f2078638d6585f54c9f05f5c2008f22ce5a2a9100ada785fc065dbd"
+checksum = "7be18d8b976cddc822e52343f328b7593d26dd2f1aeadd90da071596a210d524"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.87.0"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0cf00e1f3f2eca29a779fc23b117a408b5d59ce85af2859322b9014ae0af63"
+checksum = "2f9e48bb632a2e189b38a9fa89fa5a6eea687a5a4c613bbef7c2b7522c3ad0e0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -5506,9 +5506,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7afe5b8ac42a33b4f19a53f677d7475cddceedf1eb78745b3b1f71b72fbe3d09"
+checksum = "a020a3f6587fa7a7d98a021156177735ebb07212a6239a85ab5f14b2f728508f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5537,18 +5537,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536870d7ba2008b689c1f10e98becd86f17157df3aad2f63e5f308ca13ee2f1f"
+checksum = "fed4ada1fdd4d9a2aa37be652abcc31ae3188ad0efcefb4571ef4f785be2d777"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce067f86f8eb0a0dbd245e173a6194e034a2aeed739aac64e7a56f303afe7322"
+checksum = "d96a03a5732ef39b83943d9d72de8ac2d58623d3bfaaea4d9a92aea5fcd9acf5"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -5566,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7318d12f5b1ccb71dee548f20d7df649262211fb311ceb419c129c179307f7"
+checksum = "1fc59c28fe895112db09e262fb9c483f9e7b82c78a82a6ded69567ccc0e9795b"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -5587,9 +5587,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81b3bcb90a2f95a9f4beac7c9bd6f1c11d8f47b6c9731e754b412ae2f7a028d"
+checksum = "11086e573d2635a45ac0d44697a8e4586e058cf1b190f76bea466ca2ec36c30a"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -5606,9 +5606,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb9b4c159d0bffa7e427cac4b75798096aedf48f69e137643a201ff5508db3e"
+checksum = "6e27d519024f462fb69cc1733184c3e35f60982a6b5a04e940da7ce1a6c2c47a"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -5619,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36002a22014a44c0f778022f02ed3c9eb1c47746e318deabe3e442c56608ad99"
+checksum = "d5444a78b74144718633f8642eccd7c4858f4c6f0c98ae6a3668998adf177ba2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5645,9 +5645,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53472291468f9150c955f68dbffb82fd38b55bd139a05733d268be1da723a25"
+checksum = "c2bf6a667d2a29b2b0ed42bcf7564f00c595d92c24acb4d241c7c4d950b1910c"
 dependencies = [
  "object",
  "once_cell",
@@ -5656,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525c5b664b52c02761404ddb4509c865488e0d64436d3723b542ce8f158f562f"
+checksum = "ee064ce7b563cc201cdf3bb1cc4b233f386d8c57a96e55f4c4afe6103f4bd6a1"
 dependencies = [
  "anyhow",
  "cc",
@@ -5682,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.40.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1838152db55efc5d030ed4f91e947216b7466621169da28a3fca6d2c4b6053b"
+checksum = "01e104bd9e625181d53ead85910bbc0863aa5f0c6ef96836fe9a5cc65da11b69"
 dependencies = [
  "cranelift-entity",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0"
+version = "5.0.0-pre.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2c66da08abae1c024c01d635253e402341b4060a12e99b31c7594063bf490a"
+checksum = "553f9844ad0b0824605c20fb55a661679782680410abfb1a8144c2e7e437e7a7"
 dependencies = [
  "bitflags",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "connector-run"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap 3.2.19",
@@ -1465,7 +1465,7 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "dynamodb-sink"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-connectors-common"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "http-source"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap 3.2.19",
  "fluvio-connectors-common",
@@ -2985,7 +2985,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-sink"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap 3.2.19",
@@ -3002,7 +3002,7 @@ dependencies = [
 
 [[package]]
 name = "kafka-source"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap 3.2.19",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-source"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-global-executor",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "postgres-sink"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "clap 3.2.19",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "postgres-source"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "adaptive_backoff",
  "bytes",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "slack-sink"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap 3.2.19",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "test-connector"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ members = [
     "examples/github-stars/slack-display-smartmodule-map/",
 ]
 resolver = "2"
+
+[patch.crates-io]
+fluvio = { git = "https://github.com/infinyon/fluvio" }
+fluvio-smartengine = { git = "https://github.com/infinyon/fluvio" }
+fluvio-protocol = { git = "https://github.com/infinyon/fluvio" }

--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -23,7 +23,9 @@ clap = { version = "3.1", features = ["std", "derive"], default-features = false
 
 anyhow = "1.0.56"
 fluvio-future = { version = "0.4.1", features = ["subscriber"] }
-fluvio = { version = "0.13" }
+fluvio = { git = "https://github.com/infinyon/fluvio" }
+fluvio-smartengine = { git = "https://github.com/infinyon/fluvio" }
+fluvio-protocol = { git = "https://github.com/infinyon/fluvio" }
 flate2 = { version = "1.0" }
 tokio-stream = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }

--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -23,9 +23,9 @@ clap = { version = "3.1", features = ["std", "derive"], default-features = false
 
 anyhow = "1.0.56"
 fluvio-future = { version = "0.4.1", features = ["subscriber"] }
-fluvio = { git = "https://github.com/infinyon/fluvio" }
-fluvio-smartengine = { git = "https://github.com/infinyon/fluvio" }
-fluvio-protocol = { git = "https://github.com/infinyon/fluvio" }
+fluvio = { version = "0.14" }
+fluvio-smartengine = { version = "0.4" }
+fluvio-protocol = { version = "0.8" }
 flate2 = { version = "1.0" }
 tokio-stream = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }

--- a/rust-connectors/common/Cargo.toml
+++ b/rust-connectors/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-connectors-common"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]

--- a/rust-connectors/common/src/lib.rs
+++ b/rust-connectors/common/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod fluvio {
-    pub use fluvio::{FluvioError, PartitionConsumer, RecordKey, TopicProducer};
+    pub use fluvio::{
+        metadata::topic::TopicSpec, Fluvio, FluvioError, Offset, PartitionConsumer, RecordKey,
+        TopicProducer,
+    };
 }
 
 pub mod config;

--- a/rust-connectors/common/src/lib.rs
+++ b/rust-connectors/common/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod fluvio {
     pub use fluvio::{
-        metadata::topic::TopicSpec, Fluvio, FluvioError, Offset, PartitionConsumer, RecordKey,
-        TopicProducer,
+        consumer::Record, metadata::topic::TopicSpec, Fluvio, FluvioError, Offset,
+        PartitionConsumer, RecordKey, TopicProducer,
     };
 }
 

--- a/rust-connectors/common/src/opt.rs
+++ b/rust-connectors/common/src/opt.rs
@@ -5,15 +5,16 @@ use humantime::parse_duration;
 use schemars::{schema_for, JsonSchema};
 use std::{collections::BTreeMap, time::Duration};
 
-pub use fluvio::{
-    consumer, consumer::Record, metadata::smartmodule::SmartModuleSpec, metadata::topic::TopicSpec,
-    Compression, ConsumerConfig, Fluvio, FluvioError, PartitionConsumer, TopicProducer,
-    TopicProducerConfigBuilder,
+use fluvio::{
+    metadata::smartmodule::SmartModuleSpec, metadata::topic::TopicSpec, Compression, Fluvio,
 };
 
 #[cfg(any(feature = "sink", feature = "source"))]
+use fluvio_smartengine::metadata::SmartModuleContextData;
+
+#[cfg(feature = "sink")]
 use fluvio_smartengine::metadata::{
-    SmartModuleContextData, SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
+    SmartModuleInvocation, SmartModuleInvocationWasm, SmartModuleKind,
 };
 
 use crate::error::CliError;
@@ -160,10 +161,10 @@ pub struct CommonProducerOpt {
 
 #[cfg(feature = "source")]
 impl CommonConnectorOpt {
-    pub async fn create_producer(&self) -> anyhow::Result<TopicProducer> {
+    pub async fn create_producer(&self) -> anyhow::Result<fluvio::TopicProducer> {
         let fluvio = fluvio::Fluvio::connect().await?;
         self.ensure_topic_exists().await?;
-        let config_builder = TopicProducerConfigBuilder::default();
+        let config_builder = fluvio::TopicProducerConfigBuilder::default();
         let params = self.smartmodule_parameters();
 
         // Linger
@@ -237,38 +238,10 @@ impl CommonConnectorOpt {
 
         Ok(producer)
     }
-    async fn get_aggregate_initial_value(&self, fluvio: &Fluvio) -> anyhow::Result<Vec<u8>> {
-        use tokio_stream::StreamExt;
-        if let Some(initial_value) = &self.smartmodule_common.aggregate_initial_value {
-            if initial_value == "use-last" {
-                let consumer = fluvio
-                    .partition_consumer(self.fluvio_topic.clone(), 0)
-                    .await?;
-                let stream = consumer.stream(fluvio::Offset::from_end(1)).await?;
-                let timeout = stream.timeout(Duration::from_millis(3000));
-                tokio::pin!(timeout);
-                let last_record = StreamExt::try_next(&mut timeout)
-                    .await
-                    .ok()
-                    .flatten()
-                    .transpose();
-
-                if let Ok(Some(record)) = last_record {
-                    Ok(record.value().to_vec())
-                } else {
-                    Ok(Vec::new())
-                }
-            } else {
-                Ok(initial_value.as_bytes().to_vec())
-            }
-        } else {
-            Ok(Vec::new())
-        }
-    }
 }
 #[cfg(feature = "sink")]
 impl CommonConnectorOpt {
-    pub async fn create_consumer(&self) -> anyhow::Result<PartitionConsumer> {
+    pub async fn create_consumer(&self) -> anyhow::Result<fluvio::PartitionConsumer> {
         self.ensure_topic_exists().await?;
         Ok(fluvio::consumer(&self.fluvio_topic, self.consumer_common.consumer_partition).await?)
     }
@@ -276,7 +249,9 @@ impl CommonConnectorOpt {
     pub async fn create_consumer_stream(
         &self,
     ) -> anyhow::Result<
-        impl tokio_stream::Stream<Item = Result<Record, fluvio_protocol::link::ErrorCode>>,
+        impl tokio_stream::Stream<
+            Item = Result<fluvio::consumer::Record, fluvio_protocol::link::ErrorCode>,
+        >,
     > {
         let fluvio = Fluvio::connect().await?;
         let params = self.smartmodule_parameters().into();
@@ -333,7 +308,7 @@ impl CommonConnectorOpt {
             }
             _ => None,
         };
-        let mut builder = ConsumerConfig::builder();
+        let mut builder = fluvio::ConsumerConfig::builder();
         builder.smartmodule(wasm_invocation);
         let config = builder.build()?;
         let consumer = self.create_consumer().await?;
@@ -398,6 +373,36 @@ impl CommonConnectorOpt {
                 decoder.read_to_end(&mut buffer)?;
                 Ok(buffer)
             }
+        }
+    }
+
+    #[cfg(any(feature = "sink", feature = "source"))]
+    async fn get_aggregate_initial_value(&self, fluvio: &Fluvio) -> anyhow::Result<Vec<u8>> {
+        use tokio_stream::StreamExt;
+        if let Some(initial_value) = &self.smartmodule_common.aggregate_initial_value {
+            if initial_value == "use-last" {
+                let consumer = fluvio
+                    .partition_consumer(self.fluvio_topic.clone(), 0)
+                    .await?;
+                let stream = consumer.stream(fluvio::Offset::from_end(1)).await?;
+                let timeout = stream.timeout(Duration::from_millis(3000));
+                tokio::pin!(timeout);
+                let last_record = StreamExt::try_next(&mut timeout)
+                    .await
+                    .ok()
+                    .flatten()
+                    .transpose();
+
+                if let Ok(Some(record)) = last_record {
+                    Ok(record.value().to_vec())
+                } else {
+                    Ok(Vec::new())
+                }
+            } else {
+                Ok(initial_value.as_bytes().to_vec())
+            }
+        } else {
+            Ok(Vec::new())
         }
     }
 }

--- a/rust-connectors/common/test-data/connectors/full-config.yaml
+++ b/rust-connectors/common/test-data/connectors/full-config.yaml
@@ -26,3 +26,8 @@ producer:
   compression: gzip
 consumer:
   partition: 10
+transform:
+  - uses: infinyon/json-sql
+    invoke: insert
+    with:
+      table: "topic_message"

--- a/rust-connectors/common/test-data/connectors/full-config.yaml
+++ b/rust-connectors/common/test-data/connectors/full-config.yaml
@@ -26,7 +26,7 @@ producer:
   compression: gzip
 consumer:
   partition: 10
-transform:
+transforms:
   - uses: infinyon/json-sql
     invoke: insert
     with:

--- a/rust-connectors/common/test-data/connectors/with_transform.yaml
+++ b/rust-connectors/common/test-data/connectors/with_transform.yaml
@@ -1,0 +1,22 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+transform:
+  - uses: infinyon/sql
+    invoke: insert
+    with:
+      table: "topic_message"
+      map-columns:
+        "device_id":
+          json-key: "device.device_id"
+          value:
+            type: "int"
+            default: 0
+            required: true
+        "record":
+          json-key: "$"
+          value:
+            type: "jsonb"
+            required: true

--- a/rust-connectors/common/test-data/connectors/with_transform.yaml
+++ b/rust-connectors/common/test-data/connectors/with_transform.yaml
@@ -3,7 +3,7 @@ name: my-test-mqtt
 type: mqtt
 topic: my-mqtt
 create_topic: false
-transform:
+transforms:
   - uses: infinyon/sql
     invoke: insert
     with:

--- a/rust-connectors/common/test-data/connectors/with_transform_many.yaml
+++ b/rust-connectors/common/test-data/connectors/with_transform_many.yaml
@@ -3,7 +3,7 @@ name: my-test-mqtt
 type: mqtt
 topic: my-mqtt
 create_topic: false
-transform:
+transforms:
   - uses: infinyon/json-sql
     invoke: insert
     with:

--- a/rust-connectors/common/test-data/connectors/with_transform_many.yaml
+++ b/rust-connectors/common/test-data/connectors/with_transform_many.yaml
@@ -1,0 +1,14 @@
+version: 0.1.0
+name: my-test-mqtt
+type: mqtt
+topic: my-mqtt
+create_topic: false
+transform:
+  - uses: infinyon/json-sql
+    invoke: insert
+    with:
+      table: "topic_message"
+  - uses: infinyon/avro-sql
+    invoke: insert
+    with:
+      table: "topic_message"

--- a/rust-connectors/sinks/dynamodb/Cargo.toml
+++ b/rust-connectors/sinks/dynamodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynamodb-sink"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sinks/dynamodb/src/main.rs
+++ b/rust-connectors/sinks/dynamodb/src/main.rs
@@ -6,8 +6,9 @@ use aws_sdk_dynamodb::{
     Client, Endpoint,
 };
 use clap::Parser;
+use fluvio_connectors_common::fluvio::Record;
 use fluvio_connectors_common::git_hash_version;
-use fluvio_connectors_common::opt::{CommonConnectorOpt, Record};
+use fluvio_connectors_common::opt::CommonConnectorOpt;
 use fluvio_future::tracing::{error, info};
 use schemars::{schema_for, JsonSchema};
 use serde_json::value::Value;

--- a/rust-connectors/sinks/kafka/Cargo.toml
+++ b/rust-connectors/sinks/kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-sink"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sinks/postgres/Cargo.toml
+++ b/rust-connectors/sinks/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-sink"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [dependencies]

--- a/rust-connectors/sinks/slack/Cargo.toml
+++ b/rust-connectors/sinks/slack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-sink"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sinks/slack/src/main.rs
+++ b/rust-connectors/sinks/slack/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
+use fluvio_connectors_common::fluvio::Record;
 use fluvio_connectors_common::git_hash_version;
-use fluvio_connectors_common::opt::{CommonConnectorOpt, Record};
+use fluvio_connectors_common::opt::CommonConnectorOpt;
 use fluvio_future::tracing::{debug, info};
 use schemars::schema_for;
 use schemars::JsonSchema;

--- a/rust-connectors/sources/http/Cargo.toml
+++ b/rust-connectors/sources/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-source"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Fluvio connector that fetches data from HTTP endpoints"
 edition = "2021"
 

--- a/rust-connectors/sources/kafka/Cargo.toml
+++ b/rust-connectors/sources/kafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka-source"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sources/mqtt/Cargo.toml
+++ b/rust-connectors/sources/mqtt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt-source"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-connectors/sources/postgres/Cargo.toml
+++ b/rust-connectors/sources/postgres/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/bin/main.rs"
 tracing = { version = "0.1" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1" }
-fluvio = { version = "0.13" }
 fluvio-future = { version = "0.4", features = ["subscriber", "timer"] }
 fluvio-connectors-common = { path = "../../common", features = ["source"]}
 fluvio-model-postgres = { path = "../../models/fluvio-model-postgres" }
@@ -43,4 +42,5 @@ adaptive_backoff = "0.2.1"
 
 [dev-dependencies]
 fluvio-future = { version = "0.4.1", features = ["fixture"] }
+fluvio = { version = "0.13", default-features = false }
 uuid = { version = "1.1", features = ["serde", "v4"] }

--- a/rust-connectors/sources/postgres/Cargo.toml
+++ b/rust-connectors/sources/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-source"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 [[bin]]
 name = "postgres-source"

--- a/rust-connectors/sources/postgres/src/connect.rs
+++ b/rust-connectors/sources/postgres/src/connect.rs
@@ -1,7 +1,6 @@
 use crate::convert::convert_replication_event;
 use crate::{Error, PgConnectorOpt};
-use fluvio::metadata::topic::TopicSpec;
-use fluvio::{Fluvio, Offset, TopicProducer};
+use fluvio_connectors_common::fluvio::{Fluvio, Offset, RecordKey, TopicProducer, TopicSpec};
 use fluvio_model_postgres::{Column, LogicalReplicationMessage, ReplicationEvent};
 use once_cell::sync::Lazy;
 use postgres_protocol::message::backend::{
@@ -197,7 +196,7 @@ impl PgConnector {
                 let event = convert_replication_event(&self.relations, &xlog_data)?;
                 let json = serde_json::to_string(&event)?;
 
-                self.producer.send(fluvio::RecordKey::NULL, json).await?;
+                self.producer.send(RecordKey::NULL, json).await?;
 
                 match event.message {
                     LogicalReplicationMessage::Relation(rel) => {

--- a/rust-connectors/sources/syslog/Cargo.toml
+++ b/rust-connectors/sources/syslog/Cargo.toml
@@ -11,7 +11,7 @@ structopt = "0.3"
 fluvio = "0.13"
 thiserror = "1.0.25"
 tokio = { version = "1.20.0", features = ["macros", "rt", ] }
-notify = "5.0.0-pre.14"
+notify = "=5.0.0-pre.15"
 futures-util = "0.3.15"
 cfg-if = "1.0.0"
 

--- a/rust-connectors/utils/connector-run/Cargo.toml
+++ b/rust-connectors/utils/connector-run/Cargo.toml
@@ -14,4 +14,6 @@ k8-types = { version = "0.6.0", default-features = false, features = ["app"] }
 k8-client = "7.0.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_yaml = "0.8.18"
+serde_json = { version = "1", default-features = false}
 tokio = { version = "1", features = ["full"] }
+itertools = { version = "0.10", default-features = false }

--- a/rust-connectors/utils/connector-run/Cargo.toml
+++ b/rust-connectors/utils/connector-run/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "connector-run"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Deploy or run locally a connector"
 

--- a/rust-connectors/utils/connector-run/src/local.rs
+++ b/rust-connectors/utils/connector-run/src/local.rs
@@ -16,7 +16,7 @@ impl LocalOpt {
     pub fn execute(self) -> anyhow::Result<()> {
         let config = ConnectorConfig::from_file(self.config)?;
 
-        let args = build_args(&config);
+        let args = build_args(&config)?;
         let type_ = &config.type_;
         let image = format!("infinyon/fluvio-connect-{}:{}", type_, config.version);
 

--- a/rust-connectors/utils/connector-run/src/main.rs
+++ b/rust-connectors/utils/connector-run/src/main.rs
@@ -170,9 +170,8 @@ fn build_args(config: &ConnectorConfig) -> anyhow::Result<Vec<String>> {
     let mut args = vec!["--".to_string(), format!("--fluvio-topic={}", config.topic)];
     args.extend(parameters);
 
-    if let Some(ref transform_params) = config.transform {
+    if let Some(ref transform_params) = config.transforms {
         let transforms: Result<Vec<String>, serde_json::Error> = transform_params
-            .0
             .iter()
             .map(serde_json::to_string)
             .map_ok(|transform| format!("--transform={}", transform))

--- a/rust-connectors/utils/test-connector/Cargo.toml
+++ b/rust-connectors/utils/test-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-connector"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Added `transform` section to Connector config.
The yaml config example:
```yaml
transform:
  - uses: infinyon/json-sql
    invoke: insert
    with:
      table: "topic_message"
      map-columns:
        "device_id":
          json-key: "device.device_id"
          value:
            type: "int"
            default: 0
            required: true
        "record":
          json-key: "$"
          value:
            type: "jsonb"
            required: true
```
Everything in `with` section has a free format depending on the smartmodule receiver, which defined in `uses` section.

Related #328  