### PR TITLE
feat(mqtt): added `json` payload output type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt-source"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-global-executor",

--- a/rust-connectors/sources/mqtt/Cargo.toml
+++ b/rust-connectors/sources/mqtt/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mqtt-source"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 tracing = "0.1"
-fluvio-connectors-common = { path = "../../common" }
+fluvio-connectors-common = { path = "../../common", features=["source"] }
 fluvio-future = { version = "0.4.1", features = ["subscriber", "timer"] }
 uuid = { version = "1.1", features = ["v4"] }
 

--- a/rust-connectors/sources/mqtt/README.md
+++ b/rust-connectors/sources/mqtt/README.md
@@ -12,14 +12,15 @@ MQTT V3.1.1 and V5
 
 ### Source Configuration
 
-#### Paramaters
+#### Parameters
 
-| Option        | default  | type   | description                                             |
-| :---          | :---     | :---   | :----                                                   |
-| timeout       | 60       | u64    | mqtt broker connect timeout in seconds                  |
-| mqtt_url      | -        | String | mqtt_url MQTT url which includes schema, domain and port. *USE MQTT_URL* in secrets if you need to supply credentials such as username and password.|
-| mqtt_topic    | -        | String | mqtt topic to subscribe and source events from          |
-| client_id     | UUID V4  | String | mqtt client ID                                          |
+| Option              | default  | type     | description                                                                                                                                          |
+|:--------------------|:---------|:---------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| timeout             | 60       | u64      | mqtt broker connect timeout in seconds                                                                                                               |
+| mqtt_url            | -        | String   | mqtt_url MQTT url which includes schema, domain and port. *USE MQTT_URL* in secrets if you need to supply credentials such as username and password. |
+| mqtt_topic          | -        | String   | mqtt topic to subscribe and source events from                                                                                                       |
+| client_id           | UUID V4  | String   | mqtt client ID                                                                                                                                       |
+| payload_output_type | binary   | String   | controls how the output of `payload` field is produced                                                                                               |
 
 #### Secrets
 
@@ -33,6 +34,22 @@ None - Record output is UTF-8 JSON Serialized String.
 
 ### Record Type Output
 
-| Matrix  | Output |
-| :---    | :---   |
-| default | JSON Serialized string with fields `mqtt_topic` and `payload` holding array of bytes |
+| Matrix  | Output                                                        |
+| :---    |:--------------------------------------------------------------|
+| default | JSON Serialized string with fields `mqtt_topic` and `payload` |
+
+### Payload Output Configuration
+
+Controls how the output of `payload` field is produced
+
+| Option              | default | type     | 
+|:--------------------|:--------|:---------|
+| payload_output_type | binary  | String   | 
+
+
+### Payload Output Type
+
+| Value  | Output                       |
+|:-------|:-----------------------------|
+| binary | Array of bytes               |
+| json   | UTF-8 JSON Serialized String |

--- a/rust-connectors/sources/mqtt/src/formatter.rs
+++ b/rust-connectors/sources/mqtt/src/formatter.rs
@@ -1,0 +1,109 @@
+use crate::opt::OutputType;
+use crate::MqttEvent;
+use anyhow::Context;
+use serde::Serialize;
+use serde_json::Value;
+
+pub(crate) trait Formatter {
+    fn to_string(&self, event: &MqttEvent) -> anyhow::Result<String>;
+}
+
+pub(crate) fn from_output_type(output_type: &OutputType) -> Box<dyn Formatter> {
+    match output_type {
+        OutputType::Binary => Box::new(BinaryPayload {}),
+        OutputType::Json => Box::new(JsonPayload {}),
+    }
+}
+
+struct BinaryPayload {}
+
+struct JsonPayload {}
+
+impl Formatter for BinaryPayload {
+    fn to_string(&self, event: &MqttEvent) -> anyhow::Result<String> {
+        Ok(serde_json::to_string(event)?)
+    }
+}
+
+impl Formatter for JsonPayload {
+    fn to_string(&self, event: &MqttEvent) -> anyhow::Result<String> {
+        let payload: Value = serde_json::from_slice(event.payload.as_slice())
+            .context("payload is not valid JSON")?;
+        #[derive(Serialize)]
+        struct Record<'a> {
+            mqtt_topic: &'a str,
+            payload: Value,
+        }
+        let record = Record {
+            mqtt_topic: event.mqtt_topic.as_str(),
+            payload,
+        };
+        Ok(serde_json::to_string(&record)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_binary_payload_formatting() -> anyhow::Result<()> {
+        //given
+        let formatter = from_output_type(&OutputType::Binary);
+        let event = MqttEvent {
+            mqtt_topic: "topic".to_string(),
+            payload: b"hello world".to_vec(),
+        };
+
+        //when
+        let result = formatter.to_string(&event)?;
+
+        //then
+        let deserialized: MqttEvent = serde_json::from_str(&result)?;
+        assert_eq!(deserialized.mqtt_topic, "topic");
+        assert_eq!(deserialized.payload, b"hello world");
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_payload_formatting() -> anyhow::Result<()> {
+        //given
+        let formatter = from_output_type(&OutputType::Json);
+        let event = MqttEvent {
+            mqtt_topic: "topic".to_string(),
+            payload: b"{\"key\":\"value\"}".to_vec(),
+        };
+
+        //when
+        let result = formatter.to_string(&event)?;
+
+        //then
+        let expected_json = json!({
+            "mqtt_topic": "topic",
+            "payload": {
+                "key": "value"
+            }
+
+        });
+        assert_eq!(result, serde_json::to_string(&expected_json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_payload_formatting_invalid_json() {
+        //given
+        let formatter = from_output_type(&OutputType::Json);
+        let event = MqttEvent {
+            mqtt_topic: "topic".to_string(),
+            payload: b"not json".to_vec(),
+        };
+
+        //when
+        let result = formatter.to_string(&event);
+
+        //then
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "payload is not valid JSON");
+    }
+}

--- a/rust-connectors/sources/mqtt/src/main.rs
+++ b/rust-connectors/sources/mqtt/src/main.rs
@@ -1,53 +1,23 @@
 use fluvio_connectors_common::fluvio::RecordKey;
 use fluvio_connectors_common::git_hash_version;
-use fluvio_connectors_common::opt::CommonConnectorOpt;
 
 mod error;
+mod formatter;
+mod opt;
+
 use error::MqttConnectorError;
 
+use crate::opt::{ConnectorDirection, MqttOpts};
 use clap::Parser;
 use fluvio_future::tracing::{debug, error, info};
 use rumqttc::{v4::Packet, AsyncClient, ClientConfig, Event, MqttOptions, QoS, Transport};
-use schemars::{schema_for, JsonSchema};
+use schemars::schema_for;
+use serde::Deserialize;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::time::Duration;
 use url::Url;
 
-#[derive(Parser, Debug, JsonSchema)]
-struct MqttOpts {
-    #[clap(long)]
-    timeout: Option<u64>,
-
-    #[clap(short, long, env = "MQTT_URL", hide_env_values = true)]
-    mqtt_url: String,
-
-    #[clap(long)]
-    mqtt_topic: String,
-
-    #[clap(long)]
-    client_id: Option<String>,
-
-    #[clap(flatten)]
-    #[schemars(flatten)]
-    common: CommonConnectorOpt,
-}
-
-#[derive(Debug, Serialize)]
-struct MySchema {
-    name: &'static str,
-    direction: ConnectorDirection,
-    schema: schemars::schema::RootSchema,
-    version: &'static str,
-    description: &'static str,
-}
-
-#[derive(Debug, Serialize)]
-#[allow(dead_code)] // The other variants aren't used but are part of the spec.
-enum ConnectorDirection {
-    Source,
-    Sink,
-}
 fn main() -> Result<(), MqttConnectorError> {
     let arguments: Vec<String> = std::env::args().collect();
     let opts: MqttOpts = match arguments.get(1) {
@@ -73,6 +43,8 @@ fn main() -> Result<(), MqttConnectorError> {
         git_hash = git_hash_version(),
         "Starting MQTT source connector",
     );
+
+    debug!("opts={:?}", opts);
 
     async_global_executor::block_on(async move {
         let mqtt_timeout_seconds = Duration::from_secs(opts.timeout.unwrap_or(60));
@@ -117,13 +89,13 @@ fn main() -> Result<(), MqttConnectorError> {
             mqttoptions.set_transport(Transport::tls_with_config(client_config.into()));
         }
         let producer = opts.common.create_producer().await?;
-
+        let formatter = formatter::from_output_type(&opts.payload_output_type);
         loop {
             let (client, mut eventloop) = AsyncClient::new(mqttoptions.clone(), 10);
             client
                 .subscribe(mqtt_topic.clone(), QoS::AtMostOnce)
                 .await?;
-            tracing::info!("Connected to Fluvio");
+            info!("Connected to Fluvio");
             loop {
                 let notification = match eventloop.poll().await {
                     Ok(notification) => notification,
@@ -133,7 +105,7 @@ fn main() -> Result<(), MqttConnectorError> {
                     }
                 };
                 if let Ok(mqtt_event) = MqttEvent::try_from(notification) {
-                    let fluvio_record = serde_json::to_string(&mqtt_event)?;
+                    let fluvio_record = formatter.to_string(&mqtt_event)?;
                     debug!("Record before smartstream {}", fluvio_record);
                     if let Err(e) = producer.send(RecordKey::NULL, fluvio_record).await {
                         error!("Fluvio error! {}", e);
@@ -142,20 +114,29 @@ fn main() -> Result<(), MqttConnectorError> {
                     }
                 }
             }
-            fluvio_future::timer::sleep(std::time::Duration::from_secs(5)).await;
+            fluvio_future::timer::sleep(Duration::from_secs(5)).await;
             debug!("reconnecting to mqtt and fluvio");
         }
     })
 }
 
 #[derive(Debug, Serialize)]
+struct MySchema {
+    name: &'static str,
+    direction: ConnectorDirection,
+    schema: schemars::schema::RootSchema,
+    version: &'static str,
+    description: &'static str,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct MqttEvent {
     mqtt_topic: String,
     payload: Vec<u8>,
 }
-impl TryFrom<rumqttc::Event> for MqttEvent {
+impl TryFrom<Event> for MqttEvent {
     type Error = String;
-    fn try_from(event: rumqttc::Event) -> Result<Self, Self::Error> {
+    fn try_from(event: Event) -> Result<Self, Self::Error> {
         match event {
             Event::Incoming(Packet::Publish(p)) => Ok(Self {
                 mqtt_topic: p.topic,

--- a/rust-connectors/sources/mqtt/src/opt.rs
+++ b/rust-connectors/sources/mqtt/src/opt.rs
@@ -1,0 +1,84 @@
+use clap::Parser;
+use fluvio_connectors_common::opt::CommonConnectorOpt;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+#[derive(Parser, Debug, JsonSchema)]
+pub(crate) struct MqttOpts {
+    #[clap(long)]
+    pub timeout: Option<u64>,
+
+    #[clap(short, long, env = "MQTT_URL", hide_env_values = true)]
+    pub mqtt_url: String,
+
+    #[clap(long)]
+    pub mqtt_topic: String,
+
+    #[clap(long)]
+    pub client_id: Option<String>,
+
+    #[clap(flatten)]
+    #[schemars(flatten)]
+    pub common: CommonConnectorOpt,
+
+    /// Record payload output type
+    #[clap(long, default_value_t = Default::default())]
+    pub payload_output_type: OutputType,
+}
+
+#[derive(Debug, Serialize)]
+#[allow(dead_code)] // The other variants aren't used but are part of the spec.
+pub(crate) enum ConnectorDirection {
+    Source,
+    Sink,
+}
+
+#[derive(Parser, Debug, Default, JsonSchema, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OutputType {
+    #[default]
+    Binary,
+    Json,
+}
+
+impl Display for OutputType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_value(self) {
+            Ok(Value::String(s)) => write!(f, "{}", s),
+            _ => Err(std::fmt::Error),
+        }
+    }
+}
+
+impl FromStr for OutputType {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(Value::String(s.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_output_type_parse() -> anyhow::Result<()> {
+        //given
+        let binary_type_value = "binary";
+        let json_type_value = "json";
+
+        //when
+        let type1 = OutputType::from_str(binary_type_value)?;
+        let type2 = OutputType::from_str(json_type_value)?;
+
+        //then
+        assert_eq!(type1.to_string(), binary_type_value);
+        assert_eq!(type2.to_string(), json_type_value);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Added new parameter `payload_output_type` that defines the format of `payload` field: `binary`(the current one and the future default one) and `json`. 