### PR TITLE
[Merged by Bors] - fix: fixed arch resolution for linux and arm 64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
 # TARGET?=x86_64-unknown-linux-musl
 # Build docker image for Fluvio.
-ARCH=$(shell uname -m)
+ARCH=$(shell rustc --print cfg | grep target_arch | cut -d '=' -f 2 | sed 's/"//g')
 ifndef TARGET
-ifeq ($(ARCH),arm64)
-TARGET=aarch64-unknown-linux-musl
-else
-TARGET=x86_64-unknown-linux-musl
-endif
+TARGET=${ARCH}-unknown-linux-musl
 endif
 
 RUSTV?=stable


### PR DESCRIPTION
Fixing the inconvenience that `uname -m` returns `arm64` for macos M1 and `aarch64` for linux arm 64. Using `rustc` as the source of truth. 