### PR TITLE
[Merged by Bors] - fix: excluded monitoring module for compilation for windows

### DIFF
--- a/rust-connectors/common/src/lib.rs
+++ b/rust-connectors/common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fluvio {
 pub mod config;
 pub(crate) mod error;
 pub mod metrics;
+#[cfg(not(target_os = "windows"))]
 pub mod monitoring;
 #[cfg(any(feature = "source", feature = "sink"))]
 pub mod opt;


### PR DESCRIPTION
The monitoring module is coupled to unix hosts. We exclude it for windows to prevent compilation errors.