### PR TITLE
[Merged by Bors] - decouple-mqtt-fluvio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-global-executor",
+ "async-std",
  "clap 3.2.23",
  "fluvio-connectors-common",
  "fluvio-future 0.4.2",

--- a/rust-connectors/sources/mqtt/Cargo.toml
+++ b/rust-connectors/sources/mqtt/Cargo.toml
@@ -7,17 +7,21 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1"
-fluvio-connectors-common = { path = "../../common", features=["source"] }
+fluvio-connectors-common = { path = "../../common", features = ["source"] }
 fluvio-future = { version = "0.4.1", features = ["subscriber", "timer"] }
 uuid = { version = "1.1", features = ["v4"] }
-
+async-std = "1.12.0"
 thiserror = "1.0.29"
-async-global-executor = { version = "2.3.0", features = ["tokio"]}
-clap = { version = "3.1", features = ["std", "derive", "env"], default-features = false }
+async-global-executor = { version = "2.3.0", features = ["tokio"] }
+clap = { version = "3.1", features = [
+    "std",
+    "derive",
+    "env",
+], default-features = false }
 
 schemars = "0.8.6"
 serde_json = "1.0.68"
-serde = {version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive"] }
 anyhow = "1.0.56"
 url = "2.2"
 rustls = "0.20.4"

--- a/rust-connectors/sources/mqtt/src/error.rs
+++ b/rust-connectors/sources/mqtt/src/error.rs
@@ -29,6 +29,8 @@ pub enum MqttConnectorError {
     ParseError(#[from] ParseError),
     #[error("Anyhow Error: `{0:#?}`.")]
     Anyhow(#[from] AnyhowError),
+    #[error("Internal Channel Closed")]
+    ChannelClosed,
 }
 
 impl From<MqttError> for MqttConnectorError {

--- a/rust-connectors/sources/mqtt/src/formatter.rs
+++ b/rust-connectors/sources/mqtt/src/formatter.rs
@@ -8,7 +8,7 @@ pub(crate) trait Formatter {
     fn to_string(&self, event: &MqttEvent) -> anyhow::Result<String>;
 }
 
-pub(crate) fn from_output_type(output_type: &OutputType) -> Box<dyn Formatter> {
+pub(crate) fn from_output_type(output_type: &OutputType) -> Box<dyn Formatter + Sync + Send> {
     match output_type {
         OutputType::Binary => Box::new(BinaryPayload {}),
         OutputType::Json => Box::new(JsonPayload {}),

--- a/rust-connectors/sources/mqtt/src/main.rs
+++ b/rust-connectors/sources/mqtt/src/main.rs
@@ -1,4 +1,6 @@
-use fluvio_connectors_common::fluvio::RecordKey;
+use async_std::channel::{self, Receiver, Sender};
+use async_std::task::spawn;
+use fluvio_connectors_common::fluvio::{RecordKey, TopicProducer};
 use fluvio_connectors_common::{common_initialize, git_hash_version};
 
 mod error;
@@ -6,6 +8,9 @@ mod formatter;
 mod opt;
 
 use error::MqttConnectorError;
+use formatter::Formatter;
+use rumqttc::EventLoop;
+use tracing::log::warn;
 
 use crate::opt::{ConnectorDirection, MqttOpts};
 use clap::Parser;
@@ -18,6 +23,68 @@ use serde::Serialize;
 use std::convert::TryFrom;
 use std::time::Duration;
 use url::Url;
+
+const CHANNEL_BUFFER_SIZE: usize = 500;
+
+async fn mqtt_loop(
+    tx: Sender<MqttEvent>,
+    mut eventloop: EventLoop,
+) -> Result<(), MqttConnectorError> {
+    let mut should_log_warning = true;
+    loop {
+        // eventloop.poll() docs state "Don't block while iterating"
+        let notification = match eventloop.poll().await {
+            Ok(notification) => notification,
+            Err(e) => {
+                error!("Mqtt error {}", e);
+                continue;
+            }
+        };
+
+        if let Ok(mqtt_event) = MqttEvent::try_from(notification) {
+            match tx.try_send(mqtt_event) {
+                Ok(_) => {
+                    should_log_warning = true;
+                }
+                Err(e) => match e {
+                    async_std::channel::TrySendError::Full(_) => {
+                        if should_log_warning {
+                            warn!("Queue backed up, dropping mqtt messages");
+                            should_log_warning = false;
+                        }
+                    }
+                    async_std::channel::TrySendError::Closed(_) => {
+                        error!("Channel closed");
+                        return Err(MqttConnectorError::ChannelClosed);
+                    }
+                },
+            }
+        }
+    }
+}
+
+async fn fluvio_loop(
+    rx: Receiver<MqttEvent>,
+    producer: TopicProducer,
+    formatter: Box<dyn Formatter + Sync + Send>,
+) -> Result<(), MqttConnectorError> {
+    loop {
+        let mqtt_event = match rx.recv().await {
+            Ok(mqtt_event) => mqtt_event,
+            Err(_) => {
+                error!("Channel closed");
+                return Err(MqttConnectorError::ChannelClosed);
+            }
+        };
+        let fluvio_record = formatter.to_string(&mqtt_event)?;
+        debug!("Record before smartstream {}", fluvio_record);
+        if let Err(e) = producer.send(RecordKey::NULL, fluvio_record).await {
+            error!("Fluvio error! {}", e);
+            producer.clear_errors().await;
+            fluvio_future::timer::sleep(Duration::from_secs(5));
+        }
+    }
+}
 
 fn main() -> Result<(), MqttConnectorError> {
     common_initialize!();
@@ -57,6 +124,7 @@ fn main() -> Result<(), MqttConnectorError> {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         let mut url = Url::parse(&opts.mqtt_url)?;
+
         if !url.query_pairs().any(|(key, _)| key == "client_id") {
             url.query_pairs_mut().append_pair("client_id", &client_id);
         }
@@ -91,34 +159,17 @@ fn main() -> Result<(), MqttConnectorError> {
             mqttoptions.set_transport(Transport::tls_with_config(client_config.into()));
         }
         let producer = opts.common.create_producer("mqtt").await?;
+        info!("Connected to Fluvio");
         let formatter = formatter::from_output_type(&opts.payload_output_type);
-        loop {
-            let (client, mut eventloop) = AsyncClient::new(mqttoptions.clone(), 10);
-            client
-                .subscribe(mqtt_topic.clone(), QoS::AtMostOnce)
-                .await?;
-            info!("Connected to Fluvio");
-            loop {
-                let notification = match eventloop.poll().await {
-                    Ok(notification) => notification,
-                    Err(e) => {
-                        error!("Mqtt error {}", e);
-                        break;
-                    }
-                };
-                if let Ok(mqtt_event) = MqttEvent::try_from(notification) {
-                    let fluvio_record = formatter.to_string(&mqtt_event)?;
-                    debug!("Record before smartstream {}", fluvio_record);
-                    if let Err(e) = producer.send(RecordKey::NULL, fluvio_record).await {
-                        error!("Fluvio error! {}", e);
-                        producer.clear_errors().await;
-                        break;
-                    }
-                }
-            }
-            fluvio_future::timer::sleep(Duration::from_secs(5)).await;
-            debug!("reconnecting to mqtt and fluvio");
-        }
+        let (client, eventloop) = AsyncClient::new(mqttoptions.clone(), 10);
+        client
+            .subscribe(mqtt_topic.clone(), QoS::AtMostOnce)
+            .await?;
+        let (tx, rx) = channel::bounded(CHANNEL_BUFFER_SIZE);
+        let mqtt_jh = spawn(mqtt_loop(tx, eventloop));
+        let fluvio_jh = spawn(fluvio_loop(rx, producer, formatter));
+        mqtt_jh.await?;
+        fluvio_jh.await
     })
 }
 


### PR DESCRIPTION
1. Moved mqtt consume and fluvio produce to different async loops.
2. Per rmqtt [docs](https://docs.rs/rumqttc/latest/rumqttc/struct.EventLoop.html#method.poll), should not block when iterating on `eventloop.poll()`
3. Incoming mqtt messages are dropped. Oldest messages are dropped first. If a drop every occurs, number of dropped messages is logged as most every five minutes.
